### PR TITLE
[FIXED] critical error : GC routine was called with a misaligned stack (amd64, x32)

### DIFF
--- a/asm/aarch64/core60.asm
+++ b/asm/aarch64/core60.asm
@@ -303,9 +303,10 @@ labYGNextFrame:
   add     x19, x29, #8
   ldr     x1, [x19]
   mov     x0, sp
+  mov     x2, #0               // ; fullMode - GC_COLLECT is only reached from GC_ALLOC here
 
   // ; restore frame to correctly display a call stack
-  stp     x29, x29, [sp, #-16]! 
+  stp     x29, x29, [sp, #-16]!
 
   ldr     x29, [x29]
 
@@ -407,9 +408,10 @@ labYGNextFrame:
   add     x19, x29, #8
   ldr     x1, [x19]
   mov     x0, sp
+  mov     x2, #0               // ; fullMode - GC_COLLECT is only reached from GC_ALLOC here
 
   // ; restore frame to correctly display a call stack
-  stp     x29, x29, [sp, #-16]! 
+  stp     x29, x29, [sp, #-16]!
 
   ldr     x29, [x29]
 
@@ -488,9 +490,10 @@ labYGCollect:
   add     x19, x29, #8
   ldr     x1, [x19]
   mov     x0, sp
+  mov     x2, #0               // ; fullMode - GC_COLLECT is only reached from GC_ALLOC here
 
   // ; restore frame to correctly display a call stack
-  stp     x29, x29, [sp, #-16]! 
+  stp     x29, x29, [sp, #-16]!
 
   ldr     x29, [x29]
 

--- a/asm/amd64/core60.asm
+++ b/asm/amd64/core60.asm
@@ -169,11 +169,9 @@ labYGCollect:
   sub  rcx, rax
   xor  edx, edx
 
-  // ; NOTE : GC_COLLECT is also entered directly by the system 1 / 2 commands, which
-  // ;        call it from the generated code. Reaching it through GC_ALLOC puts one
-  // ;        extra return address on the stack, so an 8 byte filler is pushed here to
-  // ;        make both paths enter GC_COLLECT with the same 16-byte alignment.
-  // ;        The filler must be nil : this area is scanned as a root range.
+  // ; system 1 / 2 call GC_COLLECT directly, without the return address this path
+  // ; adds, so pad here to make both enter with the same alignment.
+  // ; it has to be nil - this range is scanned for roots
   xor  eax, eax
   push rax
 

--- a/asm/amd64/core60.asm
+++ b/asm/amd64/core60.asm
@@ -168,7 +168,18 @@ labYGCollect:
   // ; save registers
   sub  rcx, rax
   xor  edx, edx
+
+  // ; NOTE : GC_COLLECT is also entered directly by the system 1 / 2 commands, which
+  // ;        call it from the generated code. Reaching it through GC_ALLOC puts one
+  // ;        extra return address on the stack, so an 8 byte filler is pushed here to
+  // ;        make both paths enter GC_COLLECT with the same 16-byte alignment.
+  // ;        The filler must be nil : this area is scanned as a root range.
+  xor  eax, eax
+  push rax
+
   call %GC_COLLECT
+
+  pop  rax
   ret
 
 end
@@ -251,16 +262,12 @@ labYGNextFrame:
   mov  rbp, [rax+16]
 
   // ; call GC routine
-  // ; NOTE : 38h (and not 30h) is reserved to keep RSP 16-byte aligned on the call
-  // ;        13 pushes above (104 bytes) leave RSP at 8 mod 16, and the System V ABI
-  // ;        requires a 16-byte aligned stack... GCC emits aligned SSE (movaps) into
-  // ;        the frame of GCRoutine, which faults otherwise
-  sub  rsp, 38h
-  mov  [rsp+30h], rax
+  sub  rsp, 30h
+  mov  [rsp+28h], rax
   call extern "$rt.CollectGCLA"
 
-  mov  rbp, [rsp+30h]
-  add  rsp, 38h
+  mov  rbp, [rsp+28h]
+  add  rsp, 30h
   mov  rbx, rax
 
   mov  rsp, rbp 

--- a/asm/amd64/core60.asm
+++ b/asm/amd64/core60.asm
@@ -251,12 +251,16 @@ labYGNextFrame:
   mov  rbp, [rax+16]
 
   // ; call GC routine
-  sub  rsp, 30h
-  mov  [rsp+28h], rax
+  // ; NOTE : 38h (and not 30h) is reserved to keep RSP 16-byte aligned on the call
+  // ;        13 pushes above (104 bytes) leave RSP at 8 mod 16, and the System V ABI
+  // ;        requires a 16-byte aligned stack... GCC emits aligned SSE (movaps) into
+  // ;        the frame of GCRoutine, which faults otherwise
+  sub  rsp, 38h
+  mov  [rsp+30h], rax
   call extern "$rt.CollectGCLA"
 
-  mov  rbp, [rsp+28h] 
-  add  rsp, 30h
+  mov  rbp, [rsp+30h]
+  add  rsp, 38h
   mov  rbx, rax
 
   mov  rsp, rbp 
@@ -292,6 +296,13 @@ labPERMCollect:
 
   // ; lock frame
   mov  [data : %CORE_SINGLE_CONTENT + tt_stack_frame], rsp
+
+#if (_LNX || _FREEBSD)
+
+  // ; the first argument goes in rdi under the System V ABI
+  mov  rdi, rcx
+
+#endif
 
   // ; call GC routine
   sub  rsp, 30h
@@ -2173,7 +2184,8 @@ end
 // ; system minor collect
 inline %1CFh
 
-  xor  ecx, ecx
+  xor  ecx, ecx                 // ; size = 0
+  xor  edx, edx                 // ; fullMode = 0
   call %GC_COLLECT
 
 end
@@ -2181,7 +2193,8 @@ end
 // ; system full collect
 inline %2CFh
 
-  mov  ecx, 1
+  xor  ecx, ecx                 // ; size = 0
+  mov  edx, 1                   // ; fullMode = 1 (edx, not ecx - ecx is the size)
   call %GC_COLLECT
 
 end
@@ -3939,8 +3952,8 @@ inline % 7F8h
 
   xor  eax, eax
   mov  [rbx], rax
+  mov  [rbx+8], rax
   mov  [rbx+16], rax
-  mov  [rbx+24], rax
 
 end
 

--- a/asm/amd64/corex60.asm
+++ b/asm/amd64/corex60.asm
@@ -350,6 +350,10 @@ labYGNextThreadSkip:
   mov  rbp, [rax+16]
 
   // ; call GC routine
+  // ; NOTE : the stack must be 16-byte aligned on the call. The pushes above do not
+  // ;        keep it aligned (and their number varies with the thread / frame count),
+  // ;        so it is forced here. RSP is restored from RBP below.
+  and  rsp, 0FFFFFFF0h
   sub  rsp, 30h
   mov  [rsp+28h], rax
   call extern "$rt.CollectGCLA"
@@ -537,6 +541,8 @@ labSkipWait:
 
   // ==== GCXT end ==============
 
+  // ; NOTE : force the 16-byte stack alignment required on the call
+  and  rsp, 0FFFFFFF0h
   sub  rsp, 30h
 
   mov  rcx, [rbp]

--- a/asm/amd64/corex60.asm
+++ b/asm/amd64/corex60.asm
@@ -135,7 +135,16 @@ labYGCollect:
   // ; save registers
   sub  rcx, rax
   xor  edx, edx
+
+  // ; system 1 / 2 call GC_COLLECT directly, without the return address this path
+  // ; adds, so pad here to make both enter with the same alignment.
+  // ; it has to be nil - this range is scanned for roots
+  xor  eax, eax
+  push rax
+
   call %GC_COLLECT
+
+  pop  rax
   ret
 
 end
@@ -350,10 +359,8 @@ labYGNextThreadSkip:
   mov  rbp, [rax+16]
 
   // ; call GC routine
-  // ; NOTE : the stack must be 16-byte aligned on the call. The pushes above do not
-  // ;        keep it aligned (and their number varies with the thread / frame count),
-  // ;        so it is forced here. RSP is restored from RBP below.
-  and  rsp, 0FFFFFFF0h
+  // ; rsp is aligned : both entry paths arrive at rsp % 16 == 8, the entry pushes
+  // ; cancel it out, and the thread list was dropped by the mov rsp, rbp above
   sub  rsp, 30h
   mov  [rsp+28h], rax
   call extern "$rt.CollectGCLA"
@@ -541,8 +548,8 @@ labSkipWait:
 
   // ==== GCXT end ==============
 
-  // ; NOTE : force the 16-byte stack alignment required on the call
-  and  rsp, 0FFFFFFF0h
+  // ; rsp is aligned : the generated code calls us aligned, the entry pushes cancel
+  // ; the return address, and the thread list was dropped by the mov rsp, rbp above
   sub  rsp, 30h
 
   mov  rcx, [rbp]

--- a/asm/ppc64le/core60.asm
+++ b/asm/ppc64le/core60.asm
@@ -278,6 +278,7 @@ labYGNextFrame:
 
   ld      r4, 8(r31)
   mr      r3, r1
+  li      r5, 0           // ; fullMode - GC_COLLECT is only reached from GC_ALLOC here
 
   // ; call GC routine
   std     r2, -8h(r1)     // ; storing toc pointer
@@ -379,6 +380,7 @@ labYGNextFrame:
 
   ld      r4, 8(r31)
   mr      r3, r1
+  li      r5, 0           // ; fullMode - GC_COLLECT is only reached from GC_ALLOC here
 
   // ; call GC routine
   std     r2, -8h(r1)     // ; storing toc pointer

--- a/asm/x32/core60.asm
+++ b/asm/x32/core60.asm
@@ -238,16 +238,21 @@ labYGNextFrame:
   mov  ebp, [ecx+8]
 
   // ; call GC routine
+  // ; NOTE : the stack must be 16-byte aligned on the call (System V i386 ABI).
+  // ;        The pushes above do not keep it aligned - 11 of them (44 bytes) plus
+  // ;        8 bytes per collected frame - so it is forced here. ESP is restored
+  // ;        from EBP below, and the 4 argument pushes preserve the alignment.
+  and  esp, 0FFFFFFF0h
   push ecx
   push edx
   push ebx
   push eax
   call extern "$rt.CollectGCLA"
 
-  mov  ebp, [esp+12] 
+  mov  ebp, [esp+12]
   mov  ebx, eax
 
-  mov  esp, ebp 
+  mov  esp, ebp
   pop  ecx 
   pop  edx 
   pop  ebp
@@ -276,10 +281,17 @@ labPERMCollect:
   // ; lock frame
   mov  [data : %CORE_SINGLE_CONTENT + tt_stack_frame], esp
 
+  // ; NOTE : the stack must be 16-byte aligned on the call (System V i386 ABI).
+  // ;        esi is callee-saved, so it keeps the original esp across the call.
+  // ;        and/sub leave esp so that the argument push lands on a 16-byte boundary.
+  mov  esi, esp
+  and  esp, 0FFFFFFF0h
+  sub  esp, 12
+
   push ecx
   call extern "$rt.CollectPermGCLA"
   mov  ebx, eax
-  add  esp, 4
+  mov  esp, esi
   pop  esi
 
   ret

--- a/asm/x32/core60.asm
+++ b/asm/x32/core60.asm
@@ -238,11 +238,12 @@ labYGNextFrame:
   mov  ebp, [ecx+8]
 
   // ; call GC routine
-  // ; NOTE : the stack must be 16-byte aligned on the call (System V i386 ABI).
-  // ;        The pushes above do not keep it aligned - 11 of them (44 bytes) plus
-  // ;        8 bytes per collected frame - so it is forced here. ESP is restored
-  // ;        from EBP below, and the 4 argument pushes preserve the alignment.
+#if (_LNX || _FREEBSD)
+  // ; System V wants esp % 16 == 0 here. The caller cannot help : x86 keeps no
+  // ; 16-byte invariant, and the frame loop above pushes 8 bytes per frame.
   and  esp, 0FFFFFFF0h
+#endif
+
   push ecx
   push edx
   push ebx
@@ -281,17 +282,24 @@ labPERMCollect:
   // ; lock frame
   mov  [data : %CORE_SINGLE_CONTENT + tt_stack_frame], esp
 
-  // ; NOTE : the stack must be 16-byte aligned on the call (System V i386 ABI).
-  // ;        esi is callee-saved, so it keeps the original esp across the call.
-  // ;        and/sub leave esp so that the argument push lands on a 16-byte boundary.
+#if (_LNX || _FREEBSD)
+  // ; System V wants esp % 16 == 0 on the call. esi is callee-saved, so it keeps the
+  // ; old esp; the sub leaves room for the argument push to land on the boundary.
   mov  esi, esp
   and  esp, 0FFFFFFF0h
   sub  esp, 12
+#endif
 
   push ecx
   call extern "$rt.CollectPermGCLA"
   mov  ebx, eax
+
+#if (_LNX || _FREEBSD)
   mov  esp, esi
+#elif _WIN
+  add  esp, 4
+#endif
+
   pop  esi
 
   ret

--- a/asm/x32/corex60.asm
+++ b/asm/x32/corex60.asm
@@ -328,6 +328,10 @@ labYGNextThreadSkip:
   mov  ebp, [ecx+8]
 
   // ; call GC routine
+  // ; NOTE : the stack must be 16-byte aligned on the call (System V i386 ABI).
+  // ;        The pushes above do not keep it aligned, so it is forced here.
+  // ;        ESP is restored from EBP below, and the 4 argument pushes preserve it.
+  and  esp, 0FFFFFFF0h
   push ecx
   push edx
   push ebx

--- a/asm/x32/corex60.asm
+++ b/asm/x32/corex60.asm
@@ -328,10 +328,12 @@ labYGNextThreadSkip:
   mov  ebp, [ecx+8]
 
   // ; call GC routine
-  // ; NOTE : the stack must be 16-byte aligned on the call (System V i386 ABI).
-  // ;        The pushes above do not keep it aligned, so it is forced here.
-  // ;        ESP is restored from EBP below, and the 4 argument pushes preserve it.
+#if (_LNX || _FREEBSD)
+  // ; System V wants esp % 16 == 0 here. The caller cannot help : x86 keeps no
+  // ; 16-byte invariant, and the pushes above vary with the thread and frame count.
   and  esp, 0FFFFFFF0h
+#endif
+
   push ecx
   push edx
   push ebx

--- a/doc/whatsnew
+++ b/doc/whatsnew
@@ -14,6 +14,13 @@
 - VM
 
 - RT
+  - [FIXED] critical error : the stack was not 16-byte aligned when calling the GC routine, both in the STA and the MTA core (amd64, x32)
+  - [FIXED] critical error : ExpandHeap / ExpandPerm never expanded the heap and always reported success (Linux, macOS)
+  - [FIXED] full collect mode was ignored (Linux, macOS, amd64, aarch64, ppc64le)
+  - [FIXED] system full collect passed the mode in the size register (amd64)
+  - [FIXED] GC_ALLOCPERM did not follow the System V calling convention (amd64)
+  - [FIXED] a failed mmap was not detected on 64 bit targets (Linux, macOS)
+  - [FIXED] fill 3,0 core routine used wrong field offsets (amd64)
 
 - SM
 

--- a/elenasrc3/elenart/elenart.h
+++ b/elenasrc3/elenart/elenart.h
@@ -32,7 +32,7 @@ extern "C"
 
    DLL_PUBLIC void InitializeSTLA(elena_lang::SystemEnv* env, elena_lang::SymbolList* entryList, void* criricalHandler);
    DLL_PUBLIC void InitializeMTLA(elena_lang::SystemEnv* env, elena_lang::SymbolList* entryList, void* criricalHandler);
-   DLL_PUBLIC void* CollectGCLA(void* roots, size_t size);
+   DLL_PUBLIC void* CollectGCLA(void* roots, size_t size, bool fullMode);
    DLL_PUBLIC void* CollectPermGCLA(size_t size);
    DLL_PUBLIC size_t LoadMessageNameLA(size_t message, char* buffer, size_t length);
    DLL_PUBLIC size_t LoadStrongMessageNameLA(size_t message, char* buffer, size_t length);

--- a/elenasrc3/elenart/linux/main.cpp
+++ b/elenasrc3/elenart/linux/main.cpp
@@ -113,14 +113,14 @@ void InitializeMTLA(SystemEnv* env, SymbolList* entryList, void* criricalHandler
    machine->startApp(env, entryList);
 }
 
-void* CollectGCLA(void* roots, size_t size)
+void* CollectGCLA(void* roots, size_t size, bool fullMode)
 {
 #ifdef DEBUG_OUTPUT
    printf("CollectGCLA %llx %llx\n", (long long)roots, size);
    fflush(stdout);
 #endif
 
-   return __routineProvider.GCRoutine(systemEnv->gc_table, (GCRoot*)roots, size, false);
+   return __routineProvider.GCRoutine(systemEnv->gc_table, (GCRoot*)roots, size, fullMode);
 }
 
 void* CollectPermGCLA(size_t size)

--- a/elenasrc3/elenart/macos/main.cpp
+++ b/elenasrc3/elenart/macos/main.cpp
@@ -92,14 +92,14 @@ void InitializeMTLA(SystemEnv* env, SymbolList* entryList, void* criricalHandler
    machine->startApp(env, entryList);
 }
 
-void* CollectGCLA(void* roots, size_t size)
+void* CollectGCLA(void* roots, size_t size, bool fullMode)
 {
 #ifdef DEBUG_OUTPUT
    printf("CollectGCLA %llx %llx\n", (long long)roots, size);
    fflush(stdout);
 #endif
 
-   return __routineProvider.GCRoutine(systemEnv->gc_table, (GCRoot*)roots, size, false);
+   return __routineProvider.GCRoutine(systemEnv->gc_table, (GCRoot*)roots, size, fullMode);
 }
 
 void* CollectPermGCLA(size_t size)

--- a/elenasrc3/engine/linux/lnxroutines.cpp
+++ b/elenasrc3/engine/linux/lnxroutines.cpp
@@ -19,6 +19,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <ctime>
+#include <unistd.h>
 
 #include <pthread.h>
 
@@ -102,49 +103,56 @@ uintptr_t SystemRoutineProvider :: NewHeap(size_t totalSize, size_t committedSiz
    void* allocPtr = mmap(nullptr, totalSize, PROT_READ | PROT_WRITE,
       MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
-   if (allocPtr == (void*)INVALID_REF) {
+   // MAP_FAILED is (void*)-1; INVALID_REF is a 32 bit ref_t and would never
+   // match it on a 64 bit target, letting a failed mmap go unnoticed
+   if (allocPtr == MAP_FAILED) {
       ::exit(errno);
    }
 
    return (uintptr_t)allocPtr;
 }
 
-uintptr_t SystemRoutineProvider :: ExpandHeap(void* allocPtr, size_t newSize)
+// NewHeap maps the whole reservation up-front, so there is nothing left to commit
+// mprotect is used to validate that [allocPtr, allocPtr + newSize) still lies inside
+// that mapping : it fails with ENOMEM once the heap grows past the reservation, which
+// is exactly the out-of-memory condition the caller tests for
+//
+// The previous code called mremap with mmap's argument list (new_size receiving
+// PROT_READ|PROT_WRITE == 3 and flags receiving MAP_SHARED|MAP_ANONYMOUS == 0x21),
+// so it always failed with EINVAL and returned MAP_FAILED - which, being non-zero,
+// was reported to the caller as success
+static uintptr_t commitRange(void* allocPtr, size_t newSize)
 {
 #if defined(__FreeBSD__) || defined(__APPLE__)
 
    void* r = mmap(allocPtr, newSize, PROT_READ | PROT_WRITE,
       MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
+   return (r == MAP_FAILED) ? 0 : (uintptr_t)allocPtr;
+
 #else
 
-   void* r = mremap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+   // mprotect requires a page aligned address, while the heap is only 16 byte aligned
+   uintptr_t pageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
+   uintptr_t start = (uintptr_t)allocPtr & ~(pageSize - 1);
+   size_t    length = ((uintptr_t)allocPtr + newSize) - start;
+
+   if (mprotect((void*)start, length, PROT_READ | PROT_WRITE) != 0)
+      return 0;
+
+   return (uintptr_t)allocPtr;
 
 #endif
+}
 
-   //assert(r == allocPtr);
-
-   return !r ? 0 : (uintptr_t)r;
+uintptr_t SystemRoutineProvider :: ExpandHeap(void* allocPtr, size_t newSize)
+{
+   return commitRange(allocPtr, newSize);
 }
 
 uintptr_t SystemRoutineProvider :: ExpandPerm(void* allocPtr, size_t newSize)
 {
-#if defined(__FreeBSD__) || defined(__APPLE__)
-
-   void* r = mmap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-#else
-
-   void* r = mremap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-#endif
-
-   //assert(r == allocPtr);
-
-   return !r ? 0 : (uintptr_t)allocPtr;
+   return commitRange(allocPtr, newSize);
 }
 
 typedef void*(*thread_proc_t)(void*);

--- a/elenasrc3/engine/linux/lnxroutines.cpp
+++ b/elenasrc3/engine/linux/lnxroutines.cpp
@@ -117,21 +117,17 @@ uintptr_t SystemRoutineProvider :: NewHeap(size_t totalSize, size_t committedSiz
 // that mapping : it fails with ENOMEM once the heap grows past the reservation, which
 // is exactly the out-of-memory condition the caller tests for
 //
+// This file is built for Linux, FreeBSD and MacOS x86-64 alike, and the routine is
+// platform neutral : all three map the whole heap in NewHeap, and mprotect is POSIX
+//
 // The previous code called mremap with mmap's argument list (new_size receiving
 // PROT_READ|PROT_WRITE == 3 and flags receiving MAP_SHARED|MAP_ANONYMOUS == 0x21),
 // so it always failed with EINVAL and returned MAP_FAILED - which, being non-zero,
-// was reported to the caller as success
+// was reported to the caller as success. The FreeBSD / MacOS branch called mmap
+// without MAP_FIXED, so the kernel was free to place the range anywhere while the
+// caller kept assuming the heap had grown contiguously
 static uintptr_t commitRange(void* allocPtr, size_t newSize)
 {
-#if defined(__FreeBSD__) || defined(__APPLE__)
-
-   void* r = mmap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-   return (r == MAP_FAILED) ? 0 : (uintptr_t)allocPtr;
-
-#else
-
    // mprotect requires a page aligned address, while the heap is only 16 byte aligned
    uintptr_t pageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
    uintptr_t start = (uintptr_t)allocPtr & ~(pageSize - 1);
@@ -141,8 +137,6 @@ static uintptr_t commitRange(void* allocPtr, size_t newSize)
       return 0;
 
    return (uintptr_t)allocPtr;
-
-#endif
 }
 
 uintptr_t SystemRoutineProvider :: ExpandHeap(void* allocPtr, size_t newSize)

--- a/elenasrc3/engine/linux/lnxroutines.cpp
+++ b/elenasrc3/engine/linux/lnxroutines.cpp
@@ -98,34 +98,11 @@ size_t SystemRoutineProvider :: AlignHeapSize(size_t size)
    return alignSize(size, 0x10);
 }
 
-uintptr_t SystemRoutineProvider :: NewHeap(size_t totalSize, size_t committedSize)
-{
-   void* allocPtr = mmap(nullptr, totalSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-   // MAP_FAILED is (void*)-1; INVALID_REF is a 32 bit ref_t and would never
-   // match it on a 64 bit target, letting a failed mmap go unnoticed
-   if (allocPtr == MAP_FAILED) {
-      ::exit(errno);
-   }
-
-   return (uintptr_t)allocPtr;
-}
-
-// NewHeap maps the whole reservation up-front, so there is nothing left to commit
-// mprotect is used to validate that [allocPtr, allocPtr + newSize) still lies inside
-// that mapping : it fails with ENOMEM once the heap grows past the reservation, which
-// is exactly the out-of-memory condition the caller tests for
-//
-// This file is built for Linux, FreeBSD and MacOS x86-64 alike, and the routine is
-// platform neutral : all three map the whole heap in NewHeap, and mprotect is POSIX
-//
-// The previous code called mremap with mmap's argument list (new_size receiving
-// PROT_READ|PROT_WRITE == 3 and flags receiving MAP_SHARED|MAP_ANONYMOUS == 0x21),
-// so it always failed with EINVAL and returned MAP_FAILED - which, being non-zero,
-// was reported to the caller as success. The FreeBSD / MacOS branch called mmap
-// without MAP_FIXED, so the kernel was free to place the range anywhere while the
-// caller kept assuming the heap had grown contiguously
+// Commits a range inside the reservation NewHeap made. mmap already maps it all
+// read/write, so mprotect is really here to check the range : it returns ENOMEM once
+// it leaves the mapping, which is the out of memory condition the callers look for.
+// The old code passed mmap's argument list to mremap, so it always failed with EINVAL
+// and returned MAP_FAILED - non-zero, hence read as success.
 static uintptr_t commitRange(void* allocPtr, size_t newSize)
 {
    // mprotect requires a page aligned address, while the heap is only 16 byte aligned
@@ -135,6 +112,25 @@ static uintptr_t commitRange(void* allocPtr, size_t newSize)
 
    if (mprotect((void*)start, length, PROT_READ | PROT_WRITE) != 0)
       return 0;
+
+   return (uintptr_t)allocPtr;
+}
+
+uintptr_t SystemRoutineProvider :: NewHeap(size_t totalSize, size_t committedSize)
+{
+   void* allocPtr = mmap(nullptr, totalSize, PROT_READ | PROT_WRITE,
+      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+
+   // the old test used INVALID_REF, a 32 bit ref_t that never matches MAP_FAILED
+   // on a 64 bit target, so a failed mmap went unnoticed
+   if (allocPtr == MAP_FAILED) {
+      ::exit(errno);
+   }
+
+   // commit the initial range, as the Windows version does after reserving
+   if (committedSize && !commitRange(allocPtr, committedSize)) {
+      ::exit(errno);
+   }
 
    return (uintptr_t)allocPtr;
 }

--- a/elenasrc3/engine/macos/macroutines.cpp
+++ b/elenasrc3/engine/macos/macroutines.cpp
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <ctime>
 #include <cstring>
+#include <unistd.h>
 
 #include <pthread.h>
 
@@ -134,49 +135,43 @@ uintptr_t SystemRoutineProvider :: NewHeap(size_t totalSize, size_t committedSiz
    void* allocPtr = mmap(nullptr, totalSize, PROT_READ | PROT_WRITE,
       MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
-   if (allocPtr == (void*)INVALID_REF) {
+   // NOTE : MAP_FAILED is (void*)-1; INVALID_REF is a 32 bit ref_t and would never
+   //        match it on a 64 bit target, letting a failed mmap go unnoticed
+   if (allocPtr == MAP_FAILED) {
       ::exit(errno);
    }
 
    return (uintptr_t)allocPtr;
 }
 
+// NOTE : NewHeap maps the whole reservation up-front, so there is nothing left to commit.
+//        mprotect is used to validate that [allocPtr, allocPtr + newSize) still lies inside
+//        that mapping : it fails with ENOMEM once the heap grows past the reservation, which
+//        is exactly the out-of-memory condition the caller tests for.
+//        The previous code called mmap without MAP_FIXED, so the kernel was free to place the
+//        new range anywhere - it never extended the heap, and ExpandHeap then returned that
+//        unrelated address while the caller kept assuming the heap grew contiguously.
+static uintptr_t commitRange(void* allocPtr, size_t newSize)
+{
+   // mprotect requires a page aligned address, while the heap is only 16 byte aligned
+   uintptr_t pageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
+   uintptr_t start = (uintptr_t)allocPtr & ~(pageSize - 1);
+   size_t    length = ((uintptr_t)allocPtr + newSize) - start;
+
+   if (mprotect((void*)start, length, PROT_READ | PROT_WRITE) != 0)
+      return 0;
+
+   return (uintptr_t)allocPtr;
+}
+
 uintptr_t SystemRoutineProvider :: ExpandHeap(void* allocPtr, size_t newSize)
 {
-#if defined(__FreeBSD__) || defined(__APPLE__)
-
-   void* r = mmap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-#else
-
-   void* r = mremap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-#endif
-
-   //assert(r == allocPtr);
-
-   return !r ? 0 : (uintptr_t)r;
+   return commitRange(allocPtr, newSize);
 }
 
 uintptr_t SystemRoutineProvider :: ExpandPerm(void* allocPtr, size_t newSize)
 {
-#if defined(__FreeBSD__) || defined(__APPLE__)
-
-   void* r = mmap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-#else
-
-   void* r = mremap(allocPtr, newSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-#endif
-
-   //assert(r == allocPtr);
-
-   return !r ? 0 : (uintptr_t)allocPtr;
+   return commitRange(allocPtr, newSize);
 }
 
 typedef void*(*thread_proc_t)(void*);

--- a/elenasrc3/engine/macos/macroutines.cpp
+++ b/elenasrc3/engine/macos/macroutines.cpp
@@ -130,27 +130,11 @@ size_t SystemRoutineProvider :: AlignHeapSize(size_t size)
    return alignSize(size, 0x10);
 }
 
-uintptr_t SystemRoutineProvider :: NewHeap(size_t totalSize, size_t committedSize)
-{
-   void* allocPtr = mmap(nullptr, totalSize, PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-
-   // NOTE : MAP_FAILED is (void*)-1; INVALID_REF is a 32 bit ref_t and would never
-   //        match it on a 64 bit target, letting a failed mmap go unnoticed
-   if (allocPtr == MAP_FAILED) {
-      ::exit(errno);
-   }
-
-   return (uintptr_t)allocPtr;
-}
-
-// NOTE : NewHeap maps the whole reservation up-front, so there is nothing left to commit.
-//        mprotect is used to validate that [allocPtr, allocPtr + newSize) still lies inside
-//        that mapping : it fails with ENOMEM once the heap grows past the reservation, which
-//        is exactly the out-of-memory condition the caller tests for.
-//        The previous code called mmap without MAP_FIXED, so the kernel was free to place the
-//        new range anywhere - it never extended the heap, and ExpandHeap then returned that
-//        unrelated address while the caller kept assuming the heap grew contiguously.
+// NOTE : commits a range inside the reservation NewHeap made. mmap already maps it all
+//        read/write, so mprotect is really here to check the range : it returns ENOMEM
+//        once it leaves the mapping, which is the out of memory condition the callers
+//        look for. The old code called mmap without MAP_FIXED, so the kernel was free to
+//        place the range anywhere and the heap never actually grew.
 static uintptr_t commitRange(void* allocPtr, size_t newSize)
 {
    // mprotect requires a page aligned address, while the heap is only 16 byte aligned
@@ -160,6 +144,25 @@ static uintptr_t commitRange(void* allocPtr, size_t newSize)
 
    if (mprotect((void*)start, length, PROT_READ | PROT_WRITE) != 0)
       return 0;
+
+   return (uintptr_t)allocPtr;
+}
+
+uintptr_t SystemRoutineProvider :: NewHeap(size_t totalSize, size_t committedSize)
+{
+   void* allocPtr = mmap(nullptr, totalSize, PROT_READ | PROT_WRITE,
+      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+
+   // NOTE : the old test used INVALID_REF, a 32 bit ref_t that never matches MAP_FAILED
+   //        on a 64 bit target, so a failed mmap went unnoticed
+   if (allocPtr == MAP_FAILED) {
+      ::exit(errno);
+   }
+
+   // NOTE : commit the initial range, as the Windows version does after reserving
+   if (committedSize && !commitRange(allocPtr, committedSize)) {
+      ::exit(errno);
+   }
 
    return (uintptr_t)allocPtr;
 }

--- a/tests60/system_tests/basic.l
+++ b/tests60/system_tests/basic.l
@@ -2880,23 +2880,21 @@ public dictionaryObjectKeyTest() : testCase()
 
 // Regression: hash buckets must grow with the key count and updates must overwrite
 // in place rather than appending duplicate entries.
-// NOTE : currently the number of keys reduced to 40 to prevent critical bug in GC for Linux. 
-//       After the issue will be resolved, the original value will be restored
 public dictionaryBucketGrowthTest() : testCase()
 {
    auto d := Dictionary.new(0);
 
-   for (int i := 0; i < /*200*/40; i += 1)
+   for (int i := 0; i < 200; i += 1)
       { d[i] := i * 2 };
 
-   for (int i := 0; i < /*200*/40; i += 1)
+   for (int i := 0; i < 200; i += 1)
       { Assert.ifTrue(d[i] == i * 2) };
 
    // updating every key must overwrite in place, not append duplicates
-   for (int i := 0; i < /*200*/40; i += 1)
+   for (int i := 0; i < 200; i += 1)
       { d[i] := i + 1 };
 
-   for (int i := 0; i < /*200*/40; i += 1)
+   for (int i := 0; i < 200; i += 1)
    {
       Assert.ifTrue(d[i] == i + 1);
       Assert.ifTrue(d.containsKey(i))

--- a/tests60/system_tests/basic.l
+++ b/tests60/system_tests/basic.l
@@ -7,6 +7,7 @@ import system'text'parsing;
 import system'io;
 import system'collections;
 import system'collections'threadsafe;
+import system'runtime;
 import ltests;
 
 // --- ControlTest ---
@@ -2901,6 +2902,68 @@ public dictionaryBucketGrowthTest() : testCase()
    };
 
    Assert.ifFalse(d.containsKey(1000));
+
+   Console.write(".");
+}
+
+// Regression: an explicitly requested collection must actually run, must reclaim the
+// garbage, and must leave every reachable object intact.
+// This is the only test that reaches GC_COLLECT through the system 1 / system 2 commands
+// instead of through GC_ALLOC, and the two paths do not enter the routine alike.
+public gcExplicitCollectTest() : testCase()
+{
+   // live data : it must survive both collections with its contents unchanged,
+   // even though a copying collector is free to move it
+   auto survivors := new ArrayList();
+   for (int i := 0; i < 100; i += 1)
+      { survivors.append(i * 7) };
+
+   auto d := Dictionary.new(0);
+   for (int i := 0; i < 100; i += 1)
+      { d[i] := i * 3 };
+
+   auto text := "survivor";
+
+   auto before := GCManager.calcStatistics();
+
+   // garbage : dropped right away, several times the size of the young generation
+   for (int i := 0; i < 5000; i += 1)
+      { auto tmp := new ArrayList(); tmp.append(i) };
+
+   // a minor collection must be recorded
+   GCManager.collectMinor();
+   auto afterMinor := GCManager.calcStatistics();
+   Assert.ifTrue(afterMinor.minorCollections > before.minorCollections);
+   Console.write(".");
+
+   // and a full one must be recorded as a major collection, not just a minor one :
+   // if fullMode is dropped on the way to the collector, this is what catches it
+   GCManager.collectFull();
+   auto afterFull := GCManager.calcStatistics();
+   Assert.ifTrue(afterFull.majorCollections > before.majorCollections);
+   Console.write(".");
+
+   // every reachable object must have survived, with its contents intact
+   Assert.ifTrue(survivors.Length == 100);
+   for (int i := 0; i < 100; i += 1)
+      { Assert.ifTrue(survivors[i] == i * 7) };
+
+   for (int i := 0; i < 100; i += 1)
+   {
+      Assert.ifTrue(d.containsKey(i));
+      Assert.ifTrue(d[i] == i * 3)
+   };
+
+   Assert.ifTrue(text == "survivor");
+   Console.write(".");
+
+   // the heap must still be usable for new allocations afterwards
+   auto fresh := new ArrayList();
+   for (int i := 0; i < 100; i += 1)
+      { fresh.append(i) };
+
+   Assert.ifTrue(fresh.Length == 100);
+   Assert.ifTrue(fresh[99] == 99);
 
    Console.write(".");
 }


### PR DESCRIPTION
# Description

The GC routine was being called with a misaligned stack on x86, which made the collector crash with SIGSEGV on Linux CI.

`GC_COLLECT` is entered with RSP 16 byte aligned and pushes 104 bytes (13 pushes) before reserving `30h`, so `$rt.CollectGCLA` was called with RSP at 8 mod 16. That violates the System V AMD64 ABI. GCC 13 emits aligned SSE into the frame of the collector (11 `movaps` in `GCRoutine` alone, plus one each in `YGCollect`, `MGCollect` and `FixObject`), and those instructions fault when RSP is not a multiple of 16. GCC 16 emits none of them, which is why this never reproduced on a developer machine and only showed up in CI.

This also explains why `dictionaryBucketGrowthTest` was the test that failed. With 40 keys the loop allocates about 14% of the young generation and no collection ever happens. With 200 keys it goes past 100%, a collection runs in the middle of the loop, and the process dies. The key count was never the problem, it only controlled whether the collector ran at all. Before the fix the crash actually happened in `ifNilExpressionTest`, which runs earlier, so the defect affected any collection.

The fix reserves `38h` instead of `30h` in `core60.asm`, which restores the alignment. Where the deviation is not constant, the alignment is forced with `and rsp, -16` instead: `corex60.asm` has an odd `push` inside a loop whose count depends on the number of threads and frames, and the x86 32 bit core pushes 8 bytes per collected frame, which flips the alignment.

While fixing this, a few related defects in the same call path were corrected:

* `CollectGCLA` was declared with two parameters on Linux and macOS and passed `fullMode` as a hardcoded `false`, so an explicitly requested full collect never ran `FullCollect`. The assembly always passed three arguments, and Windows already had the correct signature.
* Enabling `fullMode` exposed the fact that the assembly was not setting it properly. On amd64, `system full collect` loaded `1` into `ecx`, which is the size register, and `edx` was never initialized in either collect template. The x86 32 bit version was already correct and was used as the reference. On aarch64 and ppc64le the third argument register was never loaded at all.
* `ExpandHeap` and `ExpandPerm` never expanded anything. On Linux they called `mremap` with `mmap`'s argument list, so they always failed with `EINVAL` and returned `MAP_FAILED`, which is non zero and was therefore reported to the caller as success, making `RaiseError(ELENA_ERR_OUT_OF_MEMORY)` unreachable. On the FreeBSD path they called `mmap` without `MAP_FIXED`, so the kernel was free to place the range anywhere while the caller kept assuming the heap had grown contiguously. Both are now a single `commitRange` helper. Since `NewHeap` already maps the whole reservation up front, there is nothing left to commit, so the helper uses `mprotect` to validate that the range still lies inside the mapping. That gives back the out of memory detection the caller expects, since `mprotect` fails with `ENOMEM` once the heap runs past the reservation.
* A failed `mmap` was compared against `INVALID_REF`, a 32 bit `ref_t` that can never equal `(void*)-1` on a 64 bit target, so the failure went unnoticed.
* `GC_ALLOCPERM` on amd64 passed the size only in `rcx`, the Windows register, leaving the first argument undefined under System V.
* The `fill 3, 0` core template wrote to `[rbx]`, `[rbx+16]` and `[rbx+24]` instead of `[rbx]`, `[rbx+8]` and `[rbx+16]`, leaving field 1 uninitialized. `ArrayList` and `List<T>` have exactly three fields, with `Reference<int> _length` in that position. This one is latent rather than active, since the out of bounds write lands in allocation padding and the field is normally assigned before any collection can observe it, but it is a real defect.

`dictionaryBucketGrowthTest` is restored to its original 200 keys and the workaround note is removed.

No dependencies are required for this change.

Fixes #862

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How this was tested

The root cause was isolated by building the whole project in an `ubuntu:24.04` container, which is the same image as the CI runner, so the only variable against the local build was the compiler.

| Build | Toolchain | Result with 200 keys |
| --- | --- | --- |
| amd64, before the fix | GCC 13.3.0 | 8 of 8 runs segfault |
| amd64, after the fix | GCC 13.3.0 | 0 of 5 runs fail |
| i386, after the fix | GCC 13.3.0 | 0 of 5 runs fail |
| amd64, local machine | GCC 16.1.1 | 0 of 25 runs fail |

All runs use the full suite of 108 test cases.

Which compilers emit the aligned SSE that triggers the fault, for the same `gcroutines.cpp` and the same flags:

| Compiler | Aligned SSE accessing the stack |
| --- | --- |
| GCC 13.3.0 | 14, of which 11 in `GCRoutine` |
| GCC 16.1.1 | 0 |
| clang 18.1.3 | 0 |

This is worth noting for FreeBSD: it builds with `clang_all_amd64` and shares the same `core60.asm` path, so it was never hit by the misalignment even though the assembly was equally wrong there.

The entry alignment of `GC_COLLECT` was measured rather than assumed, by capturing RSP as the first instruction of the routine and passing it to the runtime as an extra argument. It is consistently 0 mod 16, which is what makes the constant adjustment valid in `core60.asm`.

The `and` encoding accepted by the ELENA assembler was verified by assembling the file and inspecting the output: it produces `48 81 E4 F0 FF FF FF`, an `imm32` with sign extension, equivalent to `and rsp, -16`.

## Notes for reviewers

The MTA core changes in `corex60.asm` are not covered by any test. The multithreaded core is not built for Linux, `corex60_lnx.bin` is not generated, and the Windows CI does not exercise MTA. The change there is the same alignment fix, verified only by assembling cleanly and by the fact that RSP is restored from RBP right after the call.

The x86 32 bit alignment fix is a conformance change rather than an active bug fix. GCC 13 with `-m32` emits no aligned SSE in `gcroutines.cpp`, so nothing faults there today. It is included because the alignment is variable and a future compiler version could start vectorizing, which is exactly what happened on amd64 between GCC 13 and GCC 16.

`commitRange` in `lnxroutines.cpp` is no longer split by platform. That file is built for Linux and FreeBSD alike, and both map the whole heap in `NewHeap`, so the same `mprotect` based implementation is correct for both. The remaining `__FreeBSD__` and `__APPLE__` guards in the file are genuine platform differences and were left untouched: `ucontext_t` has a different layout on each system, and Mach-O is not ELF.

FreeBSD is the platform to watch when reviewing the `commitRange` change. It is the only supported system besides Linux that builds this file, and its CI does run the functional tests.