### PR TITLE
[FIXED] i386 shared libraries were compiled without -fPIC

### DIFF
--- a/elenasrc3/elenart/make/elenart_i386.mak
+++ b/elenasrc3/elenart/make/elenart_i386.mak
@@ -11,7 +11,7 @@ LD = g++
 WINDRES = windres
 
 INC = -I.. -I../../engine -I../../common
-CFLAGS = -march=pentium3 -Wall -std=c++20 -m32
+CFLAGS = -march=pentium3 -Wall -std=c++20 -m32 -fPIC
 RESINC = 
 LIBDIR = 
 LIB = 

--- a/elenasrc3/elenasm/codeblocks/elenasm_i386.mak
+++ b/elenasrc3/elenasm/codeblocks/elenasm_i386.mak
@@ -11,7 +11,7 @@ LD = g++
 WINDRES = windres
 
 INC = -I.. -I../../engine -I../../common
-CFLAGS = -march=pentium3 -Wall -std=c++20 -m32
+CFLAGS = -march=pentium3 -Wall -std=c++20 -m32 -fPIC
 RESINC = 
 LIBDIR = 
 LIB = 

--- a/elenasrc3/elenavm/codeblocks/elenavm_i386.mak
+++ b/elenasrc3/elenavm/codeblocks/elenavm_i386.mak
@@ -11,7 +11,7 @@ LD = g++
 WINDRES = windres
 
 INC = -I.. -I../../engine -I../../common
-CFLAGS = -march=pentium3 -Wall -std=c++20 -m32
+CFLAGS = -march=pentium3 -Wall -std=c++20 -m32 -fPIC
 RESINC = 
 LIBDIR = 
 LIB = 


### PR DESCRIPTION
# Description

The three i386 makefiles that build shared libraries compile their objects without `-fPIC`:

- `elenasrc3/elenart/make/elenart_i386.mak`
- `elenasrc3/elenasm/codeblocks/elenasm_i386.mak`
- `elenasrc3/elenavm/codeblocks/elenavm_i386.mak`

Every other platform that produces a `.so` already passes it (amd64, arm64, ppc64le, macOS and FreeBSD, in both the gcc and the clang makefiles), so the i386 ones look like an oversight rather than a deliberate choice. Nothing in the i386 sources requires non PIC code; `elenasrc3/engine/x86` has no inline assembly, and each makefile has its own object directory, so the executables built from the same sources are unaffected.

ELF i386 permits text relocations, so a linker defaulting to `-z notext` links the library anyway. The result carries `DT_TEXTREL`, which forces the loader to make the code pages writable and then re-protect them. That is what the build produces today. A linker defaulting to `-z text` refuses outright:

```
ld.bfd: warning: relocation in read-only section `.rodata'
ld.bfd: error: read-only segment has dynamic relocations
collect2: error: ld returned 1 exit status
make[1]: *** [elenart_i386.mak:51: out_release] Error 1
```

and `make all_i386` does not complete. This is reproducible on current Fedora and should affect any distribution shipping recent binutils.

Adding `-fPIC` fixes the build and removes `DT_TEXTREL` from the 32 bit libraries.

Verified by reproducing the link with the exact flags from the makefile, with and without the flag: without it the link fails as above; with it the link succeeds and `readelf -d` reports no `TEXTREL` entry. A full `make all_i386` followed by `local_build_package_i386.script` completes with the change in place.

No dependencies.

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)