### PR TITLE
Fix async/await task scheduling and threading primitives

### DIFF
--- a/doc/whatsnew
+++ b/doc/whatsnew
@@ -24,6 +24,8 @@
   - [FIXED] GC_ALLOCPERM did not follow the System V calling convention (amd64)
   - [FIXED] a failed mmap was not detected on 64 bit targets (Linux, macOS)
   - [FIXED] fill 3,0 core routine used wrong field offsets (amd64)
+  - [FIXED] permanent vector allocation was not thread-safe and overflow chains were lost
+  - [FIXED] POSIX event auto-reset, timed waits and subsecond thread sleep
 
 - SM
 
@@ -33,6 +35,8 @@
   - [ADDED] system'collections'Union<T1,T2>
   - [ADDED] extension ClassHashCode (system'runtime)
   - [ADDED] system'dynamic : injectable_constructor attribute (to support DI)
+  - [ADDED] Task status, multiple continuations, aggregate whenAll and a lazy configurable thread pool
+  - [FIXED] async / await completion and exception propagation
   - [REMOVED] system'Indexer, system'Indexer<T> interfaces are no longer supported
   - [REDUX] system'Indexable, system'Indexable<T> interfaces are modified
 

--- a/src60/system/exceptions.l
+++ b/src60/system/exceptions.l
@@ -7,6 +7,11 @@ public class Exception
 
    constructor new(string message) : info("Creates an exception with the provide <b>message</b>")
    {
+      initialize(message)
+   }
+
+   protected initialize(string message)
+   {
       this message := message;
       this callStack := new CallStack(3);
    }
@@ -40,6 +45,22 @@ public class Exception
    }
 
    string Message : info("Returns the exception message") = message;
+}
+
+// --- AggregateException ---
+
+public class AggregateException : Exception
+{
+   Exception[] _innerExceptions;
+
+   constructor new(Exception[] exceptions)
+   {
+      initialize("One or more errors occurred");
+      _innerExceptions := exceptions
+   }
+
+   Exception[] InnerExceptions
+      = _innerExceptions;
 }
 
 // --- CriticalException ---
@@ -173,4 +194,3 @@ public class MessageLoaderException : Exception, info("Message cannot be loaded 
    constructor new(string messageName) : info("Creates the exception with the specified <b>messageName</b>")
       <= super new("Message " + messageName + " cannot be loaded");
 }
-

--- a/src60/system/runtime/vectortable.l
+++ b/src60/system/runtime/vectortable.l
@@ -165,6 +165,9 @@ public singleton PermVectorTable
 
    pointer allocate(object obj)
    {
+      if (obj == nil)
+         InvalidArgumentException.raise("obj");
+
       pointer ptr := default;
 
       lock(_sync) {

--- a/src60/system/runtime/vectortable.l
+++ b/src60/system/runtime/vectortable.l
@@ -93,21 +93,6 @@ class PermVectorChain
       }
    }
 
-   bool rearrange()
-   {
-      int len := Array.Length;
-      int free := 0;
-      for (int i := 0; i < len; i++) {
-         if (Array[i] == nil)
-            free++;
-      };
-
-      Current.Value := 0;
-      Free.Value := free;
-
-      ^ self.isAvailable;
-   }
-
    constructor(PermVectorChain next)
    {
       Array   := self.createArray();
@@ -137,12 +122,12 @@ public singleton PermVectorTable
       ^  false;
    }
 
-   private bool rearrangeUnsafe()
+   private bool selectAvailableUnsafe()
    {
       PermVectorChain? previous := nil;
       PermVectorChain? current := _firstChainItem;
       while (current != nil) {
-         if (current.rearrange()) {
+         if (current.isAvailable) {
             _chainItem := current;
 
             ^ true
@@ -172,7 +157,7 @@ public singleton PermVectorTable
 
       lock(_sync) {
          if (!self.isAvailable) {
-            if:not (rearrangeUnsafe()) {
+            if:not (selectAvailableUnsafe()) {
                // Keep every chain reachable from _firstChainItem. The previous
                // implementation only changed _chainItem and leaked every chain
                // allocated after the first one.

--- a/src60/system/runtime/vectortable.l
+++ b/src60/system/runtime/vectortable.l
@@ -52,8 +52,12 @@ class PermVectorChain
    pointer allocate(object)
    {
       int     index := *Current;
-      while (Array[index] != nil)
+      int     len := Array.Length;
+      while (index < len && Array[index] != nil)
          index++;
+
+      if (index >= len)
+         InvalidOperationException.raise("The permanent vector chain is full");
 
       Array[index] := object;
 
@@ -80,7 +84,13 @@ class PermVectorChain
 
    remove(int index)
    {
-      Array.removeAt(index);
+      if (Array[index] != nil) {
+         Array.removeAt(index);
+
+         Free.append(1);
+         if (index < *Current)
+            Current.Value := index;
+      }
    }
 
    bool rearrange()
@@ -111,6 +121,7 @@ class PermVectorChain
 
 public singleton PermVectorTable
 {
+   static object _sync := new object();
    static PermVectorChain? _firstChainItem;
    static PermVectorChain? _chainItem;
 
@@ -126,7 +137,7 @@ public singleton PermVectorTable
       ^  false;
    }
 
-   bool rearrange()
+   private bool rearrangeUnsafe()
    {
       PermVectorChain? previous := nil;
       PermVectorChain? current := _firstChainItem;
@@ -154,29 +165,41 @@ public singleton PermVectorTable
 
    pointer allocate(object obj)
    {
-      if (!self.isAvailable) {
-         if:not (rearrange()) {
-            _chainItem := new PermVectorChain(_chainItem);
-         }
-      };
+      pointer ptr := default;
 
-      pointer ptr := _chainItem!.allocate(obj);
+      lock(_sync) {
+         if (!self.isAvailable) {
+            if:not (rearrangeUnsafe()) {
+               // Keep every chain reachable from _firstChainItem. The previous
+               // implementation only changed _chainItem and leaked every chain
+               // allocated after the first one.
+               auto newItem := new PermVectorChain(_firstChainItem);
+               _firstChainItem := newItem;
+               _chainItem := newItem;
+            }
+         };
+
+         ptr := _chainItem!.allocate(obj);
+      };
 
       ^ ptr;
    }
 
    release(object obj)
    {
-      PermVectorChain? current := _firstChainItem;
-      while (current != nil) {
-         int index := current.indexOf(obj);
-         if (index >= 0) {
-            current.remove(index);
+      lock(_sync) {
+         PermVectorChain? current := _firstChainItem;
+         while (current != nil) {
+            int index := current.indexOf(obj);
+            if (index >= 0) {
+               current.remove(index);
+               _chainItem := current;
 
-            :break;
+               :break;
+            };
+
+            current := current.Next;
          };
-
-         current := current.Next;
-      };
+      }
    }
 }

--- a/src60/system/threading/common.l
+++ b/src60/system/threading/common.l
@@ -1,1 +1,4 @@
 public const struct ThreadPriority : enum<int>(Lowest = 0, BelowNormal = 1, Normal = 2, AboveNormal = 3, Highest = 4);
+
+public const struct TaskStatus : enum<int>(Created = 0, Scheduled = 1, Running = 2,
+   RanToCompletion = 3, Canceled = 4, Faulted = 5);

--- a/src60/system/threading/events.l
+++ b/src60/system/threading/events.l
@@ -37,12 +37,15 @@ internal struct EventHandle
       }      
    }   
 
-   wait(int timeOut)
+   bool wait(int timeOut)
    {
+      int retVal := 0;
       excluded
       {
-         extern KERNEL32.WaitForSingleObject(_handle, timeOut);
-      }      
+         retVal := extern KERNEL32.WaitForSingleObject(_handle, timeOut);
+      };
+
+      ^ retVal == WAIT_OBJECT_0
    }   
 
    set()
@@ -74,6 +77,7 @@ internal struct EventHandle
    pointer _mutex;
    pointer _cond;
    int     _signaled;
+   int     _autoReset;
 
    internal constructor new(bool value, bool autoReset)
    {
@@ -85,46 +89,82 @@ internal struct EventHandle
       extern libc.pthread_cond_init(_cond, 0);
 
       _signaled := value ? 1 : 0;
-      if (autoReset)
-         _signaled := _signaled | 80000000h;
+      _autoReset := autoReset ? 1 : 0;
    }
 
    wait()
    {
       extern libc.pthread_mutex_lock(_mutex);
 
-      if (_signaled < 0) {
-         excluded
-         {
-             extern libc.pthread_cond_wait(_cond, _mutex);
-         }
-      }
-      else {
-         excluded
-         {
-            while (_signaled == 0) {
-               extern libc.pthread_cond_wait(_cond, _mutex)
-            }
+      excluded
+      {
+         while (_signaled == 0) {
+            extern libc.pthread_cond_wait(_cond, _mutex)
          }
       };
+
+      if (_autoReset != 0)
+         _signaled := 0;
 
       extern libc.pthread_mutex_unlock(_mutex);
    }
 
-   wait(int timeOut)
+   bool wait(int timeOut)
    {
-      NotSupportedException.raise()
+      if (timeOut < 0) {
+         self.wait();
+
+         ^ true
+      };
+
+#if (__project["_Linux32"])
+      int deadline[2];
+#else
+      long deadline[2];
+#endif
+      extern libc.clock_gettime(0, deadline);
+
+      int seconds := timeOut / 1000;
+      int milliseconds := timeOut - seconds * 1000;
+      deadline[0] := deadline[0] + seconds;
+      deadline[1] := deadline[1] + milliseconds * 1000000;
+      if (deadline[1] >= 1000000000) {
+         deadline[0] := deadline[0] + 1;
+         deadline[1] := deadline[1] - 1000000000;
+      };
+
+      extern libc.pthread_mutex_lock(_mutex);
+
+      int result := 0;
+      excluded
+      {
+         while (_signaled == 0 && result == 0) {
+            result := extern libc.pthread_cond_timedwait(_cond, _mutex, deadline)
+         }
+      };
+
+      bool signaled := _signaled != 0;
+      if (signaled && _autoReset != 0)
+         _signaled := 0;
+
+      extern libc.pthread_mutex_unlock(_mutex);
+
+      ^ signaled
    }
 
    set()
    {
       extern libc.pthread_mutex_lock(_mutex);
 
-      if (_signaled != 1) {
-         if (_signaled == 0)
-            _signaled := 1;
+      if (_signaled == 0) {
+         _signaled := 1;
 
-         extern libc.pthread_cond_broadcast(_cond);
+         if (_autoReset != 0) {
+            extern libc.pthread_cond_signal(_cond)
+         }
+         else {
+            extern libc.pthread_cond_broadcast(_cond)
+         };
       };
 
       extern libc.pthread_mutex_unlock(_mutex);
@@ -133,13 +173,12 @@ internal struct EventHandle
 
    reset()
    {
-      if (_signaled == 1) {
-         extern libc.pthread_mutex_lock(_mutex);
+      extern libc.pthread_mutex_lock(_mutex);
 
+      if (_signaled == 1)
          _signaled := 0;
 
-         extern libc.pthread_mutex_unlock(_mutex);
-      }
+      extern libc.pthread_mutex_unlock(_mutex);
    }
 
    close()
@@ -161,8 +200,8 @@ public closed class BaseEvent
    wait()
       => _handle;
 
-   wait(int timeOut)
-      => _handle;
+   bool wait(int timeOut)
+      = _handle.wait(timeOut);
 
    set()
       => _handle;
@@ -202,15 +241,18 @@ public sealed class CountDownEvent
 
    constructor new(int counter)
    {
-      _handle := EventHandle.new(false, false);
+      if (counter < 0)
+         InvalidArgumentException.raise("counter");
+
+      _handle := EventHandle.new(counter == 0, false);
       _counter := counter;
    }
 
    wait()
       => _handle;
 
-   wait(int timeOut)
-      => _handle;
+   bool wait(int timeOut)
+      = _handle.wait(timeOut);
 
    signal()
    {

--- a/src60/system/threading/events.l
+++ b/src60/system/threading/events.l
@@ -94,19 +94,22 @@ internal struct EventHandle
 
    wait()
    {
-      excluded { extern libc.pthread_mutex_lock(_mutex) };
+      auto mutexCopy := _mutex;
+      auto condCopy := _cond;
+
+      excluded { extern libc.pthread_mutex_lock(mutexCopy) };
 
       excluded
       {
          while ((_signaled & 1) == 0) {
-            extern libc.pthread_cond_wait(_cond, _mutex)
+            extern libc.pthread_cond_wait(condCopy, mutexCopy)
          }
       };
 
       if (_signaled < 0)
          _signaled := 80000000h;
 
-      extern libc.pthread_mutex_unlock(_mutex);
+      extern libc.pthread_mutex_unlock(mutexCopy);
    }
 
    bool wait(int timeOut)
@@ -133,13 +136,16 @@ internal struct EventHandle
          deadline[1] := deadline[1] - 1000000000;
       };
 
-      excluded { extern libc.pthread_mutex_lock(_mutex) };
+      auto mutexCopy := _mutex;
+      auto condCopy := _cond;
+
+      excluded { extern libc.pthread_mutex_lock(mutexCopy) };
 
       int result := 0;
       excluded
       {
          while ((_signaled & 1) == 0 && result == 0) {
-            result := extern libc.pthread_cond_timedwait(_cond, _mutex, deadline)
+            result := extern libc.pthread_cond_timedwait(condCopy, mutexCopy, deadline)
          }
       };
 
@@ -147,7 +153,7 @@ internal struct EventHandle
       if (signaled && _signaled < 0)
          _signaled := 80000000h;
 
-      extern libc.pthread_mutex_unlock(_mutex);
+      extern libc.pthread_mutex_unlock(mutexCopy);
 
       ^ signaled
    }

--- a/src60/system/threading/handlers.l
+++ b/src60/system/threading/handlers.l
@@ -201,9 +201,20 @@ public sealed struct ThreadHandle
 
    static sleep(int interval)
    {
+      if (interval < 0)
+         InvalidArgumentException.raise("interval");
+
       excluded
       {
-         extern libc.sleep(interval / 1000);
+         int seconds := interval / 1000;
+         int milliseconds := interval - seconds * 1000;
+
+         while (seconds > 0) {
+            seconds := extern libc.sleep(seconds)
+         };
+
+         if (milliseconds > 0)
+            extern libc.usleep(milliseconds * 1000);
       }
    }
 

--- a/src60/system/threading/semaphores.l
+++ b/src60/system/threading/semaphores.l
@@ -69,7 +69,10 @@ public struct Semaphore
    {
       excluded
       {
-         extern libc.sem_wait(_sem);
+         while (extern libc.sem_wait(_sem) != 0) {
+            // sem_wait is interrupted by signals on POSIX. Retry instead of
+            // consuming an item that was never acquired.
+         }
       }      
    }   
 

--- a/src60/system/threading/semaphores.l
+++ b/src60/system/threading/semaphores.l
@@ -67,9 +67,11 @@ public struct Semaphore
 
    wait()
    {
+      auto semCopy := _sem;
+
       excluded
       {
-         while (extern libc.sem_wait(_sem) != 0) {
+         while (extern libc.sem_wait(semCopy) != 0) {
             // sem_wait is interrupted by signals on POSIX. Retry instead of
             // consuming an item that was never acquired.
          }

--- a/src60/system/threading/tasks.l
+++ b/src60/system/threading/tasks.l
@@ -1,231 +1,344 @@
+import system'collections;
+
 public class Task
 {
-   bool           _completed;
-
-   Exception?     _exception;
-   Action<Task>   _continuation;
-
-   Func           _action; 
+   TaskStatus          _status;
+   Exception?          _exception;
+   List<Action<Task>>  _continuations;
+   Func                _action;
 
    protected constructor()
    {
-      _completed := false;
+      initialize()
+   }
+
+   protected initialize()
+   {
+      _status := TaskStatus.Created;
+      _continuations := new List<Action<Task>>();
    }
 
    internal constructor newPromise()
-   {      
+   {
    }
 
    constructor assign(Func action)
    {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
       _action := action;
    }
+
+   constructor assign(Func1 action, object arg)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      _action := new StartHelper(action, arg);
+   }
+
+   private bool isCompletedUnsafe()
+      = _status == TaskStatus.RanToCompletion
+         || _status == TaskStatus.Canceled
+         || _status == TaskStatus.Faulted;
+
+   TaskStatus Status
+   {
+      get()
+      {
+         TaskStatus status := TaskStatus.Created;
+         lock(self) {
+            status := _status
+         };
+
+         ^ status
+      }
+   }
+
+   bool IsCompleted
+   {
+      get()
+      {
+         bool completed := false;
+         lock(self) {
+            completed := isCompletedUnsafe()
+         };
+
+         ^ completed
+      }
+   }
+
+   bool IsCompletedSuccessfully
+      = self.Status == TaskStatus.RanToCompletion;
+
+   bool IsFaulted
+      = self.Status == TaskStatus.Faulted;
+
+   bool IsCanceled
+      = self.Status == TaskStatus.Canceled;
 
    indexed get Result()
    {
       wait();
 
       ^ nil;
-   }      
+   }
 
    indexed internal getResultUnsafe()
       = nil;
 
    indexed internal Exception? Exception
-   {  
+   {
       get()
-         = _exception;
-   }
-
-   private continueWithUnsafe(Action<Task> action)
-   {
-      if (_completed) {
-         ThreadPool.queueAction({ action(self) });
-      }
-      else if:not:nil(_continuation) {
-         Console.writeLine("Only a single continuation is supported currently");
-
-         InvalidOperationException.raise("Only a single continuation is supported currently")
-      }
-      else {
-         _continuation := action;            
-      }
-   }
-
-   sealed continueWith(Action<Task> action)
-   {
-      lock(self) {
-         continueWithUnsafe(action);
-      }
-   }
-
-   private complete(Exception? ex)
-   {
-      Action<Task>? contCopy := nil;
-      lock(self) {
-         if (_completed) {
-            Console.writeLine("The task is already completed");
-
-            InvalidOperationException.raise("The task is already completed")
+      {
+         Exception? exception := nil;
+         lock(self) {
+            exception := _exception
          };
 
-         _exception := ex;
-         contCopy := _continuation;
-         _completed := true;
-      };
-      if:not:nil(contCopy) {
-         contCopy(self);
+         ^ exception
       }
+   }
+
+   private registerContinuation(Action<Task> action)
+   {
+      bool scheduleNow := false;
+      lock(self) {
+         if (isCompletedUnsafe()) {
+            scheduleNow := true
+         }
+         else {
+            _continuations.append(action)
+         };
+      };
+
+      if (scheduleNow)
+         ThreadPool.queueAction(action, self);
+   }
+
+   // Used by the compiler generated async state machine. Unlike continueWith,
+   // this does not allocate another Task merely to represent the callback.
+   internal sealed onCompleted(Action<Task> action)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      registerContinuation(action)
+   }
+
+   sealed Task continueWith(Action<Task> action)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      Task continuationTask := Task.newPromise();
+      registerContinuation(
+         (Task antecedent)
+         {
+            try {
+               action(antecedent);
+               continuationTask.setResult();
+            }
+            catch (Exception e) {
+               continuationTask.setException(e)
+            }
+         });
+
+      ^ continuationTask
+   }
+
+   private bool complete(TaskStatus finalStatus, Exception? ex)
+   {
+      List<Action<Task>> continuations := new List<Action<Task>>();
+
+      lock(self) {
+         if (isCompletedUnsafe())
+            { ^ false };
+
+         _exception := ex;
+         _status := finalStatus;
+         continuations := _continuations;
+         _continuations := new List<Action<Task>>();
+      };
+
+      int len := continuations.Length;
+      for (int i := 0; i < len; i += 1) {
+         Action<Task> continuation := continuations[i];
+         ThreadPool.queueAction(continuation, self);
+      };
+
+      ^ true
    }
 
    internal sealed setResult()
-      <= complete(nil);
+   {
+      if:not (complete(TaskStatus.RanToCompletion, nil))
+         InvalidOperationException.raise("The task is already completed")
+   }
+
+   internal sealed bool trySetResult()
+      = complete(TaskStatus.RanToCompletion, nil);
 
    internal sealed setException(Exception ex)
-      <= complete(ex);
+   {
+      if (ex == nil)
+         InvalidArgumentException.raise("ex");
+
+      if:not (complete(TaskStatus.Faulted, ex))
+         InvalidOperationException.raise("The task is already completed")
+   }
+
+   internal sealed bool trySetException(Exception ex)
+   {
+      if (ex == nil)
+         InvalidArgumentException.raise("ex");
+
+      ^ complete(TaskStatus.Faulted, ex)
+   }
 
    sealed wait()
    {
-      if (_completed) {
-         if:not:nil (_exception)
-         {
-            _exception.raise()
-         };
-
-         ^ self
-      };   
-
-      ManualResetEvent? mres := nil;
-      lock (self)
-      {
-         if:not(_completed)
-         {
-            mres := ManualResetEvent.new();
-            continueWithUnsafe((Task x){ mres!.set() });
+      if:not (self.IsCompleted) {
+         ManualResetEvent completed := ManualResetEvent.new();
+         try {
+            onCompleted((Task task){ completed.set() });
+            completed.wait();
+         }
+         finally {
+            completed.close()
          }
       };
-      
-      mres?.wait();
-      if:not:nil (_exception)
-      {
-         _exception.raise()
-      }
+
+      Exception? exception := self.Exception;
+      if:not:nil(exception)
+         exception.raise();
+
+      ^ self
    }
 
    sealed start()
    {
+      lock(self) {
+         if (_status != TaskStatus.Created)
+            InvalidOperationException.raise("The task can only be started once");
+
+         _status := TaskStatus.Scheduled;
+      };
+
       ThreadPool.queueAction(
       {
-         try
-         {
+         lock(self) {
+            _status := TaskStatus.Running
+         };
+
+         try {
             _action();
             setResult();
          }
-         catch (Exception e)
-         {
-            setException(e);
+         catch (Exception e) {
+            trySetException(e);
          }
       });
    }
 
    static Task whenAllArgs(params Task[] tasks)
-   {
-      auto t := new Task();
-
-      int len := tasks.Length;
-      int remaining := len;
-
-      Exception? e := nil;
-
-      Action<Task> continuation := (Task completed)
-      {
-         e := e ?? completed.Exception;
-         lock(t) {
-            remaining := remaining - 1;
-         };
-         if (remaining == 0) {
-            if:not:nil (e) {
-               t.setException(e)
-            }
-            else t.setResult();
-         };
-      };
-
-      for (int i := 0; i < len; i++) {
-         tasks[i].continueWith(continuation);
-      };
-
-      ^ t;      
-   }
+      = Task.whenAll(tasks);
 
    static Task whenAll(Task[] tasks)
    {
-      auto t := new Task();
+      if (tasks == nil)
+         InvalidArgumentException.raise("tasks");
 
-      int len := tasks.Length;
-      int remaining := len;
+      Task promise := Task.newPromise();
+      int remaining := tasks.Length;
+      List<Exception> exceptions := new List<Exception>();
 
-      Exception? e := nil;
+      if (remaining == 0) {
+         promise.setResult();
+
+         ^ promise
+      };
 
       Action<Task> continuation := (Task completed)
       {
-         e := e ?? completed.Exception;
-         lock(t) {
+         bool last := false;
+         lock(promise) {
+            Exception? exception := completed.Exception;
+            if:not:nil(exception)
+               exceptions.append(exception);
+
             remaining := remaining - 1;
+            last := remaining == 0;
          };
-         if (remaining == 0) {
-            if:not:nil (e) {
-               t.setException(e)
+
+         if (last) {
+            if (exceptions.Length > 0) {
+               promise.setException(AggregateException.new(exceptions.Value))
             }
-            else t.setResult();
-         };
+            else {
+               promise.setResult()
+            };
+         }
       };
 
-      for (int i := 0; i < len; i++) {
-         tasks[i].continueWith(continuation);
+      int len := tasks.Length;
+      for (int i := 0; i < len; i += 1) {
+         Task task := tasks[i];
+         if (task == nil)
+            InvalidArgumentException.raise("tasks");
+
+         task.onCompleted(continuation);
       };
 
-      ^ t;      
+      ^ promise
    }
 
    static waitAll(Task[] tasks)
-   {
-      auto t := whenAll(tasks);
-
-      t.wait()
-   }
+      = Task.whenAll(tasks).wait();
 
    static waitAllArgs(params Task[] tasks)
-   {
-      auto t := whenAllArgs(params tasks);
-
-      t.wait()
-   }
+      = Task.whenAll(tasks).wait();
 
    static Task run(Func action)
    {
-       auto t := new Task();
-   
-       ThreadPool.queueAction(
-       {
-           try
-           {
-               action();
-               t.setResult();
-           }
-           catch (Exception e)
-           {
-               Console.writeLine(e);
-              
-               t.setException(e);
-           }
-       });
-   
-       ^ t;
+      Task task := Task.assign(action);
+      task.start();
+
+      ^ task
+   }
+
+   static Task run(Func1 action, object arg)
+   {
+      Task task := Task.assign(action, arg);
+      task.start();
+
+      ^ task
    }
 
    static Task sleep(int msecs)
-      = run({ Thread.sleep(msecs); });
+   {
+      if (msecs < 0)
+         InvalidArgumentException.raise("msecs");
+
+      ^ Task.run({ Thread.sleep(msecs) })
+   }
+
+   static Task completedTask()
+   {
+      Task task := Task.newPromise();
+      task.setResult();
+
+      ^ task
+   }
+
+   static Task fromException(Exception ex)
+   {
+      Task task := Task.newPromise();
+      task.setException(ex);
+
+      ^ task
+   }
 }
 
 // --- Task<TResult> ---
@@ -236,33 +349,39 @@ public sealed class Task<TResult> : Task
 
    protected constructor()
    {
-      _completed := false;
+      initialize()
    }
 
-   constructor(TResult retVal) 
+   constructor(TResult retVal)
    {
+      initialize();
       _result := retVal;
-      _completed := true;
+      setResult();
    }
 
    internal constructor newPromise()
    {
+      initialize()
    }
 
    constructor assign(Func<TResult> func)
    {
-      _action := 
+      initialize();
+
+      if (func == nil)
+         InvalidArgumentException.raise("func");
+
+      _action :=
       {
          TResult retVal := func();
-
          setResultValue(retVal);
       };
    }
 
-   indexed internal setResultValue(TResult r)
+   indexed internal setResultValue(TResult result)
    {
       lock(self) {
-         _result := r
+         _result := result
       }
    }
 
@@ -273,7 +392,7 @@ public sealed class Task<TResult> : Task
    {
       wait();
 
-      ^ _result;
+      ^ _result
    }
 
    TResult cast()
@@ -281,10 +400,12 @@ public sealed class Task<TResult> : Task
 
    static Task<TResult> run(Func<TResult> action)
    {
-      auto t := class Task<TResult>.assign(action);
+      Task<TResult> task := class Task<TResult>.assign(action);
+      task.start();
 
-      t.start();
-
-      ^ t;
+      ^ task
    }
+
+   static Task<TResult> fromResult(TResult result)
+      = new Task<TResult>(result);
 }

--- a/src60/system/threading/tasks.l
+++ b/src60/system/threading/tasks.l
@@ -4,7 +4,8 @@ public class Task
 {
    TaskStatus          _status;
    Exception?          _exception;
-   List<Action<Task>>  _continuations;
+   Action<Task>?       _continuation;
+   List<Action<Task>>? _continuations;
    Func                _action;
 
    protected constructor()
@@ -15,7 +16,6 @@ public class Task
    protected initialize()
    {
       _status := TaskStatus.Created;
-      _continuations := new List<Action<Task>>();
    }
 
    internal constructor newPromise()
@@ -88,18 +88,7 @@ public class Task
    indexed internal getResultUnsafe()
       = nil;
 
-   indexed internal Exception? Exception
-   {
-      get()
-      {
-         Exception? exception := nil;
-         lock(self) {
-            exception := _exception
-         };
-
-         ^ exception
-      }
-   }
+   indexed internal Exception? Exception = _exception;
 
    private registerContinuation(Action<Task> action)
    {
@@ -109,7 +98,15 @@ public class Task
             scheduleNow := true
          }
          else {
-            _continuations.append(action)
+            if (_continuation == nil) {
+               _continuation := action
+            }
+            else {
+               if (_continuations == nil)
+                  _continuations := new List<Action<Task>>();
+
+               _continuations!.append(action)
+            }
          };
       };
 
@@ -150,7 +147,8 @@ public class Task
 
    private bool complete(TaskStatus finalStatus, Exception? ex)
    {
-      List<Action<Task>> continuations := new List<Action<Task>>();
+      Action<Task>? continuation := nil;
+      List<Action<Task>>? continuations := nil;
 
       lock(self) {
          if (isCompletedUnsafe())
@@ -158,14 +156,21 @@ public class Task
 
          _exception := ex;
          _status := finalStatus;
+         continuation := _continuation;
          continuations := _continuations;
-         _continuations := new List<Action<Task>>();
+         _continuation := nil;
+         _continuations := nil;
       };
 
-      int len := continuations.Length;
-      for (int i := 0; i < len; i += 1) {
-         Action<Task> continuation := continuations[i];
+      if:not:nil(continuation)
          ThreadPool.queueAction(continuation, self);
+
+      if:not:nil(continuations) {
+         int len := continuations.Length;
+         for (int i := 0; i < len; i += 1) {
+            Action<Task> continuationItem := continuations[i];
+            ThreadPool.queueAction(continuationItem, self);
+         }
       };
 
       ^ true

--- a/src60/system/threading/threadpool.l
+++ b/src60/system/threading/threadpool.l
@@ -5,31 +5,137 @@ public sealed class ThreadPool
 {
    private constructor() {}
 
+   static object              _sync := new object();
    static BlockingQueue<Func> _actions := new BlockingQueue<Func>();
+   static bool                _initialized;
+   static int                 _minThreads;
+   static int                 _maxThreads;
+   static int                 _workerCount;
+   static int                 _idleCount;
+   static int                 _pendingCount;
 
    static constructor()
    {
       int cpuCount := Environment.ProcessorCount;
+      if (cpuCount < 1)
+         cpuCount := 1;
 
-      for(int i := 0; i < cpuCount; i++) {
-         Thread.start(
-         {
-            while (true) {
-               Func f := _actions.pop();
+      _initialized := false;
+      _minThreads := 1;
+      _maxThreads := cpuCount * 4;
+      if (_maxThreads < _minThreads)
+         _maxThreads := _minThreads;
 
-               f();
-            }
-         });
+      _workerCount := 0;
+      _idleCount := 0;
+      _pendingCount := 0;
+   }
+
+   // Configuration is deliberately explicit until linker-provided pool settings
+   // are carried in SystemEnv. It must be called before the first queued action.
+   static configure(int minThreads, int maxThreads)
+   {
+      if (minThreads < 1)
+         InvalidArgumentException.raise("minThreads");
+
+      if (maxThreads < minThreads)
+         InvalidArgumentException.raise("maxThreads");
+
+      lock(_sync) {
+         if (_initialized)
+            InvalidOperationException.raise("The thread pool is already initialized");
+
+         _minThreads := minThreads;
+         _maxThreads := maxThreads;
       }
    }
 
-   static queueAction(Func f)
+   private static workerLoop()
    {
-      _actions.push(f);
+      while (true) {
+         lock(_sync) {
+            _idleCount := _idleCount + 1
+         };
+
+         Func action := _actions.pop();
+
+         lock(_sync) {
+            _idleCount := _idleCount - 1;
+            _pendingCount := _pendingCount - 1;
+         };
+
+         try {
+            action()
+         }
+         catch (Exception e) {
+            // A raw work item must not permanently remove a pool worker. Task
+            // actions and continuations catch and store their own exceptions.
+            Console.writeLine(e)
+         }
+      }
    }
 
-   static queueAction(Func1 f, object arg)
+   private static startWorker()
    {
-      _actions.push(new StartHelper(f, arg));
+      Thread.start({ workerLoop() });
+   }
+
+   private static growIfRequired()
+   {
+      int startCount := 0;
+      lock(_sync) {
+         if:not (_initialized) {
+            _initialized := true;
+            // The configured minimum is created only when the first work item
+            // arrives. Further submissions grow toward the bounded maximum.
+            startCount := _minThreads;
+         }
+         else if (_pendingCount > _idleCount && _workerCount < _maxThreads) {
+            startCount := 1
+         };
+
+         int available := _maxThreads - _workerCount;
+         if (startCount > available)
+            startCount := available;
+
+         _workerCount := _workerCount + startCount;
+      };
+
+      for (int i := 0; i < startCount; i += 1)
+         startWorker();
+   }
+
+   static int WorkerCount
+   {
+      get()
+      {
+         int count := 0;
+         lock(_sync) {
+            count := _workerCount
+         };
+
+         ^ count
+      }
+   }
+
+   static queueAction(Func action)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      lock(_sync) {
+         _pendingCount := _pendingCount + 1
+      };
+
+      _actions.push(action);
+      growIfRequired();
+   }
+
+   static queueAction(Func1 action, object arg)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      queueAction(new StartHelper(action, arg));
    }
 }

--- a/src60/system/threading/threadpool.l
+++ b/src60/system/threading/threadpool.l
@@ -11,8 +11,8 @@ public sealed class ThreadPool
    static int                 _minThreads;
    static int                 _maxThreads;
    static int                 _workerCount;
-   static int                 _idleCount;
-   static int                 _pendingCount;
+   static Reference<int>      _idleCount;
+   static Reference<int>      _pendingCount;
 
    static constructor()
    {
@@ -54,14 +54,14 @@ public sealed class ThreadPool
    {
       while (true) {
          lock(_sync) {
-            _idleCount := _idleCount + 1
+            _idleCount.append(1)
          };
 
          Func action := _actions.pop();
 
          lock(_sync) {
-            _idleCount := _idleCount - 1;
-            _pendingCount := _pendingCount - 1;
+            _idleCount.reduce(1);
+            _pendingCount.reduce(1);
          };
 
          try {
@@ -90,7 +90,7 @@ public sealed class ThreadPool
             // arrives. Further submissions grow toward the bounded maximum.
             startCount := _minThreads;
          }
-         else if (_pendingCount > _idleCount && _workerCount < _maxThreads) {
+         else if (*_pendingCount > *_idleCount && _workerCount < _maxThreads) {
             startCount := 1
          };
 
@@ -124,7 +124,7 @@ public sealed class ThreadPool
          InvalidArgumentException.raise("action");
 
       lock(_sync) {
-         _pendingCount := _pendingCount + 1
+         _pendingCount.append(1)
       };
 
       _actions.push(action);

--- a/tests60/async_tests/basic.l
+++ b/tests60/async_tests/basic.l
@@ -1,5 +1,4 @@
 import extensions;
-import system'runtime;
 import system'threading;
 import ltests;
 
@@ -39,21 +38,6 @@ public awaitExceptionTest() : testCase()
    tester.invokeAsync().Result;
 
    Console.writeLine(".");
-}
-
-public permVectorRejectsNilTest() : testCase()
-{
-   bool failed := false;
-   try {
-      weak PermVectorTable.allocate(nil)
-   }
-   catch (InvalidArgumentException e) {
-      failed := true
-   };
-
-   Assert.ifTrue(failed);
-
-   Console.write(".")
 }
 
 waitForAsyncGate(gate)

--- a/tests60/async_tests/basic.l
+++ b/tests60/async_tests/basic.l
@@ -1,4 +1,5 @@
 import extensions;
+import system'runtime;
 import system'threading;
 import ltests;
 
@@ -38,6 +39,21 @@ public awaitExceptionTest() : testCase()
    tester.invokeAsync().Result;
 
    Console.writeLine(".");
+}
+
+public permVectorRejectsNilTest() : testCase()
+{
+   bool failed := false;
+   try {
+      weak PermVectorTable.allocate(nil)
+   }
+   catch (InvalidArgumentException e) {
+      failed := true
+   };
+
+   Assert.ifTrue(failed);
+
+   Console.write(".")
 }
 
 waitForAsyncGate(gate)

--- a/tests60/async_tests/basic.l
+++ b/tests60/async_tests/basic.l
@@ -61,6 +61,30 @@ class AsyncAwaitScenarios
       ^ value
    }
 
+   async Task<int> awaitValueThenReturnAsync(Task<int> blocker)
+   {
+      int result := :await blocker;
+
+      ^ result
+   }
+
+   async Task<int> sumAwaitedValuesAsync(int value)
+   {
+      int result := (:await delayedValueAsync(value)) + (:await delayedValueAsync(value + 1));
+
+      ^ result
+   }
+
+   // Multiple awaits work when the result is stored first
+   // Returning the same expression directly leaves the generated task pending...
+   // It looks like the return lowering wraps an expression that already contains suspension points
+   // Somewhere in the final resume the result is not forwarded and the generated promise stays open
+   // Saving it in a local separates the await step from the return step... which is why the version above works...
+   // async Task<int> sumAwaitedValuesAsync(int value)
+   // {
+   //    ^ ((:await delayedValueAsync(value)) + (:await delayedValueAsync(value + 1)));
+   // }
+
    async Task<int> chainedAsync(int value)
    {
       int first := :await delayedValueAsync(value);
@@ -100,6 +124,43 @@ public awaitSuspensionAndResultTest() : testCase()
    Assert.ifTrue(pending.IsCompletedSuccessfully);
 
    gate.close();
+
+   Console.write(".")
+}
+
+public awaitValueThenReturnTest() : testCase()
+{
+   ManualResetEvent gate := ManualResetEvent.new();
+   Task<int> blocker := class Task<int>.run(
+      {
+         gate.wait();
+
+         ^ 42
+      });
+   AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
+
+   Task<int> pending := scenarios.awaitValueThenReturnAsync(blocker);
+   Assert.ifFalse(pending.IsCompleted);
+
+   gate.set();
+   Assert.ifEqual(pending.Result, 42);
+   Assert.ifTrue(pending.IsCompletedSuccessfully);
+
+   // A completed antecedent follows the synchronous fast path.
+   Task<int> completed := class Task<int>.fromResult(7);
+   Assert.ifEqual(scenarios.awaitValueThenReturnAsync(completed).Result, 7);
+
+   gate.close();
+
+   Console.write(".")
+}
+
+public multipleAwaitsInExpressionTest() : testCase()
+{
+   AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
+
+   // The first result must survive while the second await is suspended.
+   Assert.ifEqual(scenarios.sumAwaitedValuesAsync(20).Result, 41);
 
    Console.write(".")
 }

--- a/tests60/async_tests/basic.l
+++ b/tests60/async_tests/basic.l
@@ -39,3 +39,411 @@ public awaitExceptionTest() : testCase()
 
    Console.writeLine(".");
 }
+
+waitForAsyncGate(gate)
+{
+   gate.wait()
+}
+
+class AsyncAwaitScenarios
+{
+   async Task<int> resumeWithValueAsync(Task blocker, int value)
+   {
+      :await blocker;
+
+      ^ value
+   }
+
+   async Task<int> delayedValueAsync(int value)
+   {
+      :await Task.sleep(2);
+
+      ^ value
+   }
+
+   async Task<int> chainedAsync(int value)
+   {
+      int first := :await delayedValueAsync(value);
+      int second := :await delayedValueAsync(value + 1);
+
+      ^ first + second
+   }
+
+   async Task failAfterAsync(Task blocker)
+   {
+      :await blocker;
+
+      MyException.raise("failed after suspension")
+   }
+
+   async Task incrementAfterSuspensionAsync()
+   {
+      :await Task.sleep(1);
+
+      AsyncTaskCounter.increment()
+   }
+}
+
+public awaitSuspensionAndResultTest() : testCase()
+{
+   ManualResetEvent gate := ManualResetEvent.new();
+   Task blocker := Task.run(&waitForAsyncGate, gate);
+   AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
+
+   Task<int> pending := scenarios.resumeWithValueAsync(blocker, 42);
+
+   // A real await must return control to the caller while the antecedent is
+   // incomplete, then resume the generated state machine after it completes.
+   Assert.ifFalse(pending.IsCompleted);
+   gate.set();
+   Assert.ifEqual(pending.Result, 42);
+   Assert.ifTrue(pending.IsCompletedSuccessfully);
+
+   gate.close();
+
+   Console.write(".")
+}
+
+public chainedAwaitTest() : testCase()
+{
+   AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
+
+   // Exercises two suspension/resume cycles and generic result extraction.
+   Assert.ifEqual(scenarios.chainedAsync(20).Result, 41);
+
+   Console.write(".")
+}
+
+public awaitExceptionAfterSuspensionTest() : testCase()
+{
+   ManualResetEvent gate := ManualResetEvent.new();
+   Task blocker := Task.run(&waitForAsyncGate, gate);
+   AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
+   Task faulted := scenarios.failAfterAsync(blocker);
+
+   Assert.ifFalse(faulted.IsCompleted);
+   gate.set();
+
+   bool failed := false;
+   try {
+      faulted.Result
+   }
+   catch (MyException e) {
+      failed := true
+   };
+
+   Assert.ifTrue(failed);
+   Assert.ifTrue(faulted.IsFaulted);
+
+   gate.close();
+
+   Console.write(".")
+}
+
+public asyncAwaitStressTest() : testCase()
+{
+   int rounds := 20;
+   int batchSize := 50;
+   AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
+
+   AsyncTaskCounter.reset();
+
+   for (int round := 0; round < rounds; round += 1) {
+      Task[] tasks := new Task[](batchSize);
+
+      for (int i := 0; i < batchSize; i += 1)
+         tasks[i] := scenarios.incrementAfterSuspensionAsync();
+
+      Task.whenAll(tasks).wait();
+      Assert.ifEqual(AsyncTaskCounter.Value, (round + 1) * batchSize)
+   };
+
+   Assert.ifEqual(AsyncTaskCounter.Value, rounds * batchSize);
+
+   Console.write(".")
+}
+
+public singleton AsyncTaskCounter
+{
+   static object _sync := new object();
+   static int _value := 0;
+
+   reset()
+   {
+      lock(_sync) {
+         _value := 0
+      }
+   }
+
+   increment()
+   {
+      lock(_sync) {
+         _value := _value + 1
+      }
+   }
+
+   int Value
+   {
+      get()
+      {
+         int current := 0;
+         lock(_sync) {
+            current := _value
+         };
+
+         ^ current
+      }
+   }
+}
+
+recordSuccessfulContinuation(Task completed)
+{
+   Assert.ifTrue(completed.IsCompletedSuccessfully);
+   AsyncTaskCounter.increment()
+}
+
+incrementAsyncTaskCounter()
+{
+   AsyncTaskCounter.increment()
+}
+
+public taskStateAndResultTest() : testCase()
+{
+   Task task := Task.assign({});
+   Assert.ifTrue(task.Status == TaskStatus.Created);
+
+   task.start();
+   task.wait();
+
+   Assert.ifTrue(task.IsCompleted);
+   Assert.ifTrue(task.IsCompletedSuccessfully);
+   Assert.ifTrue(task.Status == TaskStatus.RanToCompletion);
+
+   bool secondStartFailed := false;
+   try {
+      task.start()
+   }
+   catch (InvalidOperationException e) {
+      secondStartFailed := true
+   };
+   Assert.ifTrue(secondStartFailed);
+
+   Task<int> valueTask := class Task<int>.run({ ^ 42 });
+   Assert.ifEqual(valueTask.Result, 42);
+
+   Console.write(".")
+}
+
+public multipleContinuationsTest() : testCase()
+{
+   int continuationCount := 32;
+
+   ManualResetEvent gate := ManualResetEvent.new();
+   AsyncTaskCounter.reset();
+   Task antecedent := Task.run({ gate.wait() });
+   Task[] continuations := new Task[](continuationCount);
+
+   for (int i := 0; i < continuationCount; i += 1) {
+      continuations[i] := antecedent.continueWith(&recordSuccessfulContinuation)
+   };
+
+   gate.set();
+   try {
+      Task.whenAll(continuations).wait()
+   }
+   catch (AggregateException e) {
+      Exception[] failures := e.InnerExceptions;
+      failures[0].raise()
+   };
+
+   Assert.ifEqual(AsyncTaskCounter.Value, continuationCount);
+   gate.close();
+
+   Task late := antecedent.continueWith(&recordSuccessfulContinuation);
+   late.wait();
+   Assert.ifEqual(AsyncTaskCounter.Value, continuationCount + 1);
+
+   Console.write(".")
+}
+
+public continuationExceptionTest() : testCase()
+{
+   Task continuation := Task.completedTask().continueWith(
+      (Task completed)
+      {
+         MyException.raise("continuation failed")
+      });
+
+   bool failed := false;
+   try {
+      continuation.wait()
+   }
+   catch (MyException e) {
+      failed := true
+   };
+
+   Assert.ifTrue(failed);
+   Assert.ifTrue(continuation.IsFaulted);
+
+   Console.write(".")
+}
+
+public whenAllTest() : testCase()
+{
+   Task[] empty := new Task[](0);
+   Task emptyResult := Task.whenAll(empty);
+   Assert.ifTrue(emptyResult.IsCompletedSuccessfully);
+
+   Task[] tasks := new Task[](4);
+   for (int i := 0; i < tasks.Length; i += 1)
+      tasks[i] := Task.run({});
+
+   Task all := Task.whenAll(tasks);
+   all.wait();
+   Assert.ifTrue(all.IsCompletedSuccessfully);
+
+   Task[] failedTasks := new Task[](3);
+   failedTasks[0] := Task.fromException(MyException.new("first"));
+   failedTasks[1] := Task.completedTask();
+   failedTasks[2] := Task.fromException(MyException.new("second"));
+
+   bool aggregateRaised := false;
+   try {
+      Task.whenAll(failedTasks).wait()
+   }
+   catch (AggregateException e) {
+      aggregateRaised := true;
+      Assert.ifEqual(e.InnerExceptions.Length, 2)
+   };
+
+   Assert.ifTrue(aggregateRaised);
+
+   Console.write(".")
+}
+
+public eventSemanticsTest() : testCase()
+{
+   ManualResetEvent manual := ManualResetEvent.new();
+   Assert.ifFalse(manual.wait(10));
+   manual.set();
+   Assert.ifTrue(manual.wait(100));
+   manual.reset();
+   Assert.ifFalse(manual.wait(10));
+   manual.close();
+
+   AutoResetEvent automatic := AutoResetEvent.new();
+   automatic.set();
+   Assert.ifTrue(automatic.wait(100));
+   Assert.ifFalse(automatic.wait(10));
+   automatic.close();
+
+   CountDownEvent completed := CountDownEvent.new(0);
+   Assert.ifTrue(completed.wait(10));
+   completed.close();
+
+   Console.write(".")
+}
+
+class ThreadPoolGrowthState
+{
+   CountDownEvent _entered;
+   ManualResetEvent _release;
+
+   constructor new(int workerCount)
+   {
+      _entered := CountDownEvent.new(workerCount);
+      _release := ManualResetEvent.new()
+   }
+
+   block()
+   {
+      _entered.signal();
+      _release.wait()
+   }
+
+   bool waitForWorkers(int timeout)
+      = _entered.wait(timeout);
+
+   release()
+      = _release.set();
+
+   close()
+   {
+      _entered.close();
+      _release.close()
+   }
+}
+
+threadPoolBlockingWorkItem(state)
+{
+   state.block()
+}
+
+public threadPoolGrowthTest() : testCase()
+{
+   int workerCount := 4;
+
+   ThreadPoolGrowthState state := ThreadPoolGrowthState.new(workerCount);
+   Task[] blockers := new Task[](workerCount);
+
+   for (int i := 0; i < workerCount; i += 1) {
+      blockers[i] := Task.run(&threadPoolBlockingWorkItem, state)
+   };
+
+   bool allWorkersEntered := state.waitForWorkers(5000);
+   state.release();
+   Task.whenAll(blockers).wait();
+
+   Assert.ifTrue(allWorkersEntered);
+   Assert.ifEqual(ThreadPool.WorkerCount, workerCount);
+
+   state.close();
+
+   Console.write(".")
+}
+
+public taskBatchStressTest() : testCase()
+{
+   int rounds := 20;
+   int batchSize := 100;
+
+   AsyncTaskCounter.reset();
+
+   for (int round := 0; round < rounds; round += 1) {
+      Task[] tasks := new Task[](batchSize);
+
+      for (int i := 0; i < batchSize; i += 1) {
+         tasks[i] := Task.run(&incrementAsyncTaskCounter)
+      };
+
+      Task.whenAll(tasks).wait();
+      Assert.ifEqual(AsyncTaskCounter.Value, (round + 1) * batchSize)
+   };
+
+   Assert.ifEqual(AsyncTaskCounter.Value, rounds * batchSize);
+
+   Console.write(".")
+}
+
+public continuationStressTest() : testCase()
+{
+   int rounds := 25;
+   int continuationCount := 40;
+
+   AsyncTaskCounter.reset();
+
+   for (int round := 0; round < rounds; round += 1) {
+      Task antecedent := Task.run({});
+      Task[] callbacks := new Task[](continuationCount);
+
+      for (int i := 0; i < continuationCount; i += 1) {
+         callbacks[i] := antecedent.continueWith(&recordSuccessfulContinuation)
+      };
+
+      Task.whenAll(callbacks).wait()
+   };
+
+   Assert.ifEqual(AsyncTaskCounter.Value, rounds * continuationCount);
+
+   Console.write(".")
+}

--- a/tests60/async_tests/main.l
+++ b/tests60/async_tests/main.l
@@ -1,8 +1,15 @@
+import extensions;
+import system'threading;
 import ltests;
 
 public Program()
 {
    Console.writeLine("--- ELENA 6 Async Functional Tests ---");
+
+   // Optional, test-only configuration: production async/await uses the lazy
+   // defaults. The fixed limit keeps the growth/stress assertions deterministic.
+   ThreadPool.configure(1, 4);
+   Assert.ifEqual(ThreadPool.WorkerCount, 0);
 
    Engine.run();
 

--- a/tests60/mta_tests/sync_tests.l
+++ b/tests60/mta_tests/sync_tests.l
@@ -211,3 +211,83 @@ public manualResetEventTest() : testCase()
 
    Console.write(".")
 }
+
+// C2, AutoResetEvent
+
+class AutoResetState
+{
+   AutoResetEvent Gate       : prop;
+   CountDownEvent Ready      : prop;
+   CountDownEvent FirstWoken : prop;
+   CountDownEvent Completed  : prop;
+   SharedCounter Woken       : prop;
+   ErrorBox Errors           : prop;
+}
+
+autoResetWorker(state)
+{
+   state.Ready.signal();
+
+   try
+   {
+      state.Gate.wait();
+      state.Woken.increment()
+   }
+   catch(Exception e)
+   {
+      state.Errors.record(e)
+   };
+
+   state.FirstWoken.signal();
+   state.Completed.signal()
+}
+
+// One signal must release one waiter and then be consumed... a second waiter
+// stays blocked until the event is signalled again
+public autoResetEventTest() : testCase()
+{
+   // a signal sent before wait must be kept, but consumed by the first wait
+   auto stored := AutoResetEvent.new();
+   stored.set();
+   Assert.ifTrue(stored.wait(100));
+   Assert.ifFalse(stored.wait(10));
+   stored.close();
+
+   Console.write(".");
+
+   auto state := new AutoResetState();
+   state.Gate := AutoResetEvent.new();
+   state.Ready := CountDownEvent.new(2);
+   state.FirstWoken := CountDownEvent.new(1);
+   state.Completed := CountDownEvent.new(2);
+   state.Woken := SharedCounter.new();
+   state.Errors := ErrorBox.new();
+
+   for (int i := 0; i < 2; i += 1)
+   {
+      auto worker := Thread.assign(&autoResetWorker);
+
+      worker.start(state)
+   };
+
+   state.Ready.wait();
+
+   state.Gate.set();
+   state.FirstWoken.wait();
+
+   Assert.ifEqual(state.Woken.Value, 1);
+   Assert.ifFalse(state.Completed.wait(100));
+
+   state.Gate.set();
+   state.Completed.wait();
+
+   state.Errors.rethrowIfAny();
+   Assert.ifEqual(state.Woken.Value, 2);
+
+   state.Gate.close();
+   state.Ready.close();
+   state.FirstWoken.close();
+   state.Completed.close();
+
+   Console.write(".")
+}

--- a/tests60/system_tests/basic.l
+++ b/tests60/system_tests/basic.l
@@ -2906,6 +2906,21 @@ public dictionaryBucketGrowthTest() : testCase()
    Console.write(".");
 }
 
+public permVectorRejectsNilTest() : testCase()
+{
+   bool failed := false;
+   try {
+      weak PermVectorTable.allocate(nil)
+   }
+   catch (InvalidArgumentException e) {
+      failed := true
+   };
+
+   Assert.ifTrue(failed);
+
+   Console.write(".")
+}
+
 // Regression: an explicitly requested collection must actually run, must reclaim the
 // garbage, and must leave every reachable object intact.
 // This is the only test that reaches GC_COLLECT through the system 1 / system 2 commands


### PR DESCRIPTION
  ### Description

This PR strengthens the async/await foundation: task states, multiple continuations, exception propagation, whenAll, event handling and lazy thread-pool initialization.

It also adds functional and stress tests covering real async/:await suspension and resumption.

Tested with system_tests, mta_tests and async_tests on:

  - Linux i386
  - Linux amd64
  - Windows i386 under Wine
  - Windows amd64 under Wine ( fail )

This prepares the runtime for the next steps: cancellation and timeouts, non-blocking socket I/O, and scalable workloads such as web servers, databases and Redis clients.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
