### PR TITLE
build: improve Linux builds and add MinGW cross-build support

### DIFF
--- a/elenasrc3/elenart/make/cross_elenart_win32.mak
+++ b/elenasrc3/elenart/make/cross_elenart_win32.mak
@@ -1,0 +1,110 @@
+#------------------------------------------------------------------------------#
+# ELENA make file                                                              #
+# cross-builds bin/elenart60.dll on Linux with mingw-w64                       #
+#------------------------------------------------------------------------------#
+
+WORKDIR = `pwd`
+
+CC = i686-w64-mingw32-gcc
+CXX = i686-w64-mingw32-g++
+AR = i686-w64-mingw32-ar
+LD = i686-w64-mingw32-g++
+
+RESINC =
+LIBDIR =
+LIB =
+LDFLAGS = -shared -static
+
+INC = -I.. -I../../engine -I../../common -I../../lruntime
+CFLAGS = -Wall -std=c++20 -municode
+
+INC_RELEASE = $(INC)
+CFLAGS_RELEASE = $(CFLAGS) -O3
+LIBDIR_RELEASE = $(LIBDIR)
+LIB_RELEASE = $(LIB)
+LDFLAGS_RELEASE = $(LDFLAGS) -s
+OBJDIR_RELEASE = ../../temp/elenart_win32
+DEP_RELEASE =
+
+OBJ_RELEASE = $(OBJDIR_RELEASE)/__/__/common/config.o $(OBJDIR_RELEASE)/__/__/common/xmltree.o $(OBJDIR_RELEASE)/__/__/common/dump.o $(OBJDIR_RELEASE)/__/__/common/files.o $(OBJDIR_RELEASE)/__/__/common/paths.o $(OBJDIR_RELEASE)/__/__/common/ustring.o $(OBJDIR_RELEASE)/__/__/engine/elenamachine.o $(OBJDIR_RELEASE)/__/__/engine/bytecode.o $(OBJDIR_RELEASE)/__/__/engine/gcroutines.o $(OBJDIR_RELEASE)/__/__/engine/libman.o $(OBJDIR_RELEASE)/__/__/engine/section.o $(OBJDIR_RELEASE)/__/__/engine/module.o $(OBJDIR_RELEASE)/__/__/engine/rtmanager.o $(OBJDIR_RELEASE)/__/__/engine/windows/winroutines.o $(OBJDIR_RELEASE)/__/__/engine/windows/pehelper.o $(OBJDIR_RELEASE)/__/elenartmachine.o $(OBJDIR_RELEASE)/__/__/engine/x86/x86routines.o $(OBJDIR_RELEASE)/__/windows/dllmain.o
+OUT_RELEASE = ../../../bin/elenart60.dll
+
+all: release
+
+clean: clean_release
+
+before_release:
+	test -d ../../../bin || mkdir -p ../../../bin
+	test -d $(OBJDIR_RELEASE)/__ || mkdir -p $(OBJDIR_RELEASE)/__
+	test -d $(OBJDIR_RELEASE)/__/windows || mkdir -p $(OBJDIR_RELEASE)/__/windows
+	test -d $(OBJDIR_RELEASE)/__/__/engine || mkdir -p $(OBJDIR_RELEASE)/__/__/engine
+	test -d $(OBJDIR_RELEASE)/__/__/engine/x86 || mkdir -p $(OBJDIR_RELEASE)/__/__/engine/x86
+	test -d $(OBJDIR_RELEASE)/__/__/engine/windows || mkdir -p $(OBJDIR_RELEASE)/__/__/engine/windows
+	test -d $(OBJDIR_RELEASE)/__/__/common || mkdir -p $(OBJDIR_RELEASE)/__/__/common
+
+after_release:
+
+release: before_release out_release after_release
+
+$(OBJDIR_RELEASE)/__/__/common/config.o: ../../common/config.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/config.cpp -o $(OBJDIR_RELEASE)/__/__/common/config.o
+
+$(OBJDIR_RELEASE)/__/__/common/dump.o: ../../common/dump.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/dump.cpp -o $(OBJDIR_RELEASE)/__/__/common/dump.o
+
+$(OBJDIR_RELEASE)/__/__/common/files.o: ../../common/files.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/files.cpp -o $(OBJDIR_RELEASE)/__/__/common/files.o
+
+$(OBJDIR_RELEASE)/__/__/common/paths.o: ../../common/paths.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/paths.cpp -o $(OBJDIR_RELEASE)/__/__/common/paths.o
+
+$(OBJDIR_RELEASE)/__/__/common/ustring.o: ../../common/ustring.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/ustring.cpp -o $(OBJDIR_RELEASE)/__/__/common/ustring.o
+
+$(OBJDIR_RELEASE)/__/__/common/xmltree.o: ../../common/xmltree.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/xmltree.cpp -o $(OBJDIR_RELEASE)/__/__/common/xmltree.o
+
+$(OBJDIR_RELEASE)/__/__/engine/elenamachine.o: ../../engine/elenamachine.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/elenamachine.cpp -o $(OBJDIR_RELEASE)/__/__/engine/elenamachine.o
+
+$(OBJDIR_RELEASE)/__/__/engine/rtmanager.o: ../../engine/rtmanager.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/rtmanager.cpp -o $(OBJDIR_RELEASE)/__/__/engine/rtmanager.o
+
+$(OBJDIR_RELEASE)/__/__/engine/gcroutines.o: ../../engine/gcroutines.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/gcroutines.cpp -o $(OBJDIR_RELEASE)/__/__/engine/gcroutines.o
+
+$(OBJDIR_RELEASE)/__/__/engine/bytecode.o: ../../engine/bytecode.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/bytecode.cpp -o $(OBJDIR_RELEASE)/__/__/engine/bytecode.o
+
+$(OBJDIR_RELEASE)/__/__/engine/libman.o: ../../engine/libman.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/libman.cpp -o $(OBJDIR_RELEASE)/__/__/engine/libman.o
+
+$(OBJDIR_RELEASE)/__/__/engine/module.o: ../../engine/module.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/module.cpp -o $(OBJDIR_RELEASE)/__/__/engine/module.o
+
+$(OBJDIR_RELEASE)/__/__/engine/section.o: ../../engine/section.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/section.cpp -o $(OBJDIR_RELEASE)/__/__/engine/section.o
+
+$(OBJDIR_RELEASE)/__/elenartmachine.o: ../elenartmachine.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../elenartmachine.cpp -o $(OBJDIR_RELEASE)/__/elenartmachine.o
+
+$(OBJDIR_RELEASE)/__/__/engine/x86/x86routines.o: ../../engine/x86/x86routines.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/x86/x86routines.cpp -o $(OBJDIR_RELEASE)/__/__/engine/x86/x86routines.o
+
+$(OBJDIR_RELEASE)/__/__/engine/windows/winroutines.o: ../../engine/windows/winroutines.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/windows/winroutines.cpp -o $(OBJDIR_RELEASE)/__/__/engine/windows/winroutines.o
+
+$(OBJDIR_RELEASE)/__/__/engine/windows/pehelper.o: ../../lruntime/windows/pehelper.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../lruntime/windows/pehelper.cpp -o $(OBJDIR_RELEASE)/__/__/engine/windows/pehelper.o
+
+$(OBJDIR_RELEASE)/__/windows/dllmain.o: ../windows/dllmain.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../windows/dllmain.cpp -o $(OBJDIR_RELEASE)/__/windows/dllmain.o
+
+out_release: before_release $(OBJ_RELEASE) $(DEP_RELEASE)
+	$(LD) $(LIBDIR_RELEASE) -o $(OUT_RELEASE) $(OBJ_RELEASE)  $(LDFLAGS_RELEASE) $(LIB_RELEASE)
+
+clean_release:
+	rm -f $(OBJ_RELEASE) $(OUT_RELEASE)
+	rm -rf $(OBJDIR_RELEASE)
+
+.PHONY: before_release after_release clean_release

--- a/elenasrc3/elenart/make/cross_elenart_win64.mak
+++ b/elenasrc3/elenart/make/cross_elenart_win64.mak
@@ -1,0 +1,110 @@
+#------------------------------------------------------------------------------#
+# ELENA make file                                                              #
+# cross-builds bin/elenart60_64.dll on Linux with mingw-w64                    #
+#------------------------------------------------------------------------------#
+
+WORKDIR = `pwd`
+
+CC = x86_64-w64-mingw32-gcc
+CXX = x86_64-w64-mingw32-g++
+AR = x86_64-w64-mingw32-ar
+LD = x86_64-w64-mingw32-g++
+
+RESINC =
+LIBDIR =
+LIB =
+LDFLAGS = -m64 -shared -static
+
+INC = -I.. -I../../engine -I../../common -I../../lruntime
+CFLAGS = -Wall -std=c++20 -m64 -municode
+
+INC_RELEASE = $(INC)
+CFLAGS_RELEASE = $(CFLAGS) -O3
+LIBDIR_RELEASE = $(LIBDIR)
+LIB_RELEASE = $(LIB)
+LDFLAGS_RELEASE = $(LDFLAGS) -s
+OBJDIR_RELEASE = ../../temp/elenart64_win
+DEP_RELEASE =
+
+OBJ_RELEASE = $(OBJDIR_RELEASE)/__/__/common/config.o $(OBJDIR_RELEASE)/__/__/common/xmltree.o $(OBJDIR_RELEASE)/__/__/common/dump.o $(OBJDIR_RELEASE)/__/__/common/files.o $(OBJDIR_RELEASE)/__/__/common/paths.o $(OBJDIR_RELEASE)/__/__/common/ustring.o $(OBJDIR_RELEASE)/__/__/engine/elenamachine.o $(OBJDIR_RELEASE)/__/__/engine/bytecode.o $(OBJDIR_RELEASE)/__/__/engine/gcroutines.o $(OBJDIR_RELEASE)/__/__/engine/libman.o $(OBJDIR_RELEASE)/__/__/engine/section.o $(OBJDIR_RELEASE)/__/__/engine/module.o $(OBJDIR_RELEASE)/__/__/engine/rtmanager.o $(OBJDIR_RELEASE)/__/__/engine/windows/winroutines.o $(OBJDIR_RELEASE)/__/__/engine/windows/pehelper.o $(OBJDIR_RELEASE)/__/elenartmachine.o $(OBJDIR_RELEASE)/__/__/engine/amd64/amd64routines.o $(OBJDIR_RELEASE)/__/windows/dllmain.o
+OUT_RELEASE = ../../../bin/elenart60_64.dll
+
+all: release
+
+clean: clean_release
+
+before_release:
+	test -d ../../../bin || mkdir -p ../../../bin
+	test -d $(OBJDIR_RELEASE)/__ || mkdir -p $(OBJDIR_RELEASE)/__
+	test -d $(OBJDIR_RELEASE)/__/windows || mkdir -p $(OBJDIR_RELEASE)/__/windows
+	test -d $(OBJDIR_RELEASE)/__/__/engine || mkdir -p $(OBJDIR_RELEASE)/__/__/engine
+	test -d $(OBJDIR_RELEASE)/__/__/engine/amd64 || mkdir -p $(OBJDIR_RELEASE)/__/__/engine/amd64
+	test -d $(OBJDIR_RELEASE)/__/__/engine/windows || mkdir -p $(OBJDIR_RELEASE)/__/__/engine/windows
+	test -d $(OBJDIR_RELEASE)/__/__/common || mkdir -p $(OBJDIR_RELEASE)/__/__/common
+
+after_release:
+
+release: before_release out_release after_release
+
+$(OBJDIR_RELEASE)/__/__/common/config.o: ../../common/config.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/config.cpp -o $(OBJDIR_RELEASE)/__/__/common/config.o
+
+$(OBJDIR_RELEASE)/__/__/common/dump.o: ../../common/dump.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/dump.cpp -o $(OBJDIR_RELEASE)/__/__/common/dump.o
+
+$(OBJDIR_RELEASE)/__/__/common/files.o: ../../common/files.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/files.cpp -o $(OBJDIR_RELEASE)/__/__/common/files.o
+
+$(OBJDIR_RELEASE)/__/__/common/paths.o: ../../common/paths.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/paths.cpp -o $(OBJDIR_RELEASE)/__/__/common/paths.o
+
+$(OBJDIR_RELEASE)/__/__/common/ustring.o: ../../common/ustring.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/ustring.cpp -o $(OBJDIR_RELEASE)/__/__/common/ustring.o
+
+$(OBJDIR_RELEASE)/__/__/common/xmltree.o: ../../common/xmltree.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../common/xmltree.cpp -o $(OBJDIR_RELEASE)/__/__/common/xmltree.o
+
+$(OBJDIR_RELEASE)/__/__/engine/elenamachine.o: ../../engine/elenamachine.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/elenamachine.cpp -o $(OBJDIR_RELEASE)/__/__/engine/elenamachine.o
+
+$(OBJDIR_RELEASE)/__/__/engine/rtmanager.o: ../../engine/rtmanager.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/rtmanager.cpp -o $(OBJDIR_RELEASE)/__/__/engine/rtmanager.o
+
+$(OBJDIR_RELEASE)/__/__/engine/gcroutines.o: ../../engine/gcroutines.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/gcroutines.cpp -o $(OBJDIR_RELEASE)/__/__/engine/gcroutines.o
+
+$(OBJDIR_RELEASE)/__/__/engine/bytecode.o: ../../engine/bytecode.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/bytecode.cpp -o $(OBJDIR_RELEASE)/__/__/engine/bytecode.o
+
+$(OBJDIR_RELEASE)/__/__/engine/libman.o: ../../engine/libman.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/libman.cpp -o $(OBJDIR_RELEASE)/__/__/engine/libman.o
+
+$(OBJDIR_RELEASE)/__/__/engine/module.o: ../../engine/module.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/module.cpp -o $(OBJDIR_RELEASE)/__/__/engine/module.o
+
+$(OBJDIR_RELEASE)/__/__/engine/section.o: ../../engine/section.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/section.cpp -o $(OBJDIR_RELEASE)/__/__/engine/section.o
+
+$(OBJDIR_RELEASE)/__/elenartmachine.o: ../elenartmachine.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../elenartmachine.cpp -o $(OBJDIR_RELEASE)/__/elenartmachine.o
+
+$(OBJDIR_RELEASE)/__/__/engine/amd64/amd64routines.o: ../../engine/amd64/amd64routines.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/amd64/amd64routines.cpp -o $(OBJDIR_RELEASE)/__/__/engine/amd64/amd64routines.o
+
+$(OBJDIR_RELEASE)/__/__/engine/windows/winroutines.o: ../../engine/windows/winroutines.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../engine/windows/winroutines.cpp -o $(OBJDIR_RELEASE)/__/__/engine/windows/winroutines.o
+
+$(OBJDIR_RELEASE)/__/__/engine/windows/pehelper.o: ../../lruntime/windows/pehelper.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../../lruntime/windows/pehelper.cpp -o $(OBJDIR_RELEASE)/__/__/engine/windows/pehelper.o
+
+$(OBJDIR_RELEASE)/__/windows/dllmain.o: ../windows/dllmain.cpp
+	$(CXX) $(CFLAGS_RELEASE) $(INC_RELEASE) -c ../windows/dllmain.cpp -o $(OBJDIR_RELEASE)/__/windows/dllmain.o
+
+out_release: before_release $(OBJ_RELEASE) $(DEP_RELEASE)
+	$(LD) $(LIBDIR_RELEASE) -o $(OUT_RELEASE) $(OBJ_RELEASE)  $(LDFLAGS_RELEASE) $(LIB_RELEASE)
+
+clean_release:
+	rm -f $(OBJ_RELEASE) $(OUT_RELEASE)
+	rm -rf $(OBJDIR_RELEASE)
+
+.PHONY: before_release after_release clean_release

--- a/makefile
+++ b/makefile
@@ -53,6 +53,12 @@ elc_amd64:
 cross_elc_amd64: 
 	$(MAKE) -C elenasrc3/elc/make all -f cross_elc_amd64.mak
 
+cross_elenart_win64:
+	$(MAKE) -C elenasrc3/elenart/make all -f cross_elenart_win64.mak
+
+cross_elenart_win32:
+	$(MAKE) -C elenasrc3/elenart/make all -f cross_elenart_win32.mak
+
 sg_amd64: 
 	$(MAKE) -C elenasrc3/tools/sg/make all -f sg_amd64.mak
 
@@ -203,6 +209,12 @@ clean_elc_amd64:
 clean_cross_elc_amd64: 
 	$(MAKE) -C elenasrc3/elc/make clean -f cross_elc_amd64.mak
 
+clean_cross_elenart_win64:
+	$(MAKE) -C elenasrc3/elenart/make clean -f cross_elenart_win64.mak
+
+clean_cross_elenart_win32:
+	$(MAKE) -C elenasrc3/elenart/make clean -f cross_elenart_win32.mak
+
 clean_sg_amd64: 
 	$(MAKE) -C elenasrc3/tools/sg/make clean -f sg_amd64.mak
 
@@ -305,4 +317,4 @@ clean_asmc_mac_amd64:
 clean_asmc_mac_arm64:
 	$(MAKE) -C elenasrc3/tools/asmc/make clean -f asmc_mac_arm64.mak
 
-.PHONY: clean_elc_i386 clean_sg_i386 clean_og_i386 clean_asmc_i386 clean_ecv_i386 clean_elenart_i386 clean_elc_amd64 clean_sg_amd64 clean_og_amd64 clean_asmc_amd64 clean_ecv_amd64 clean_elenart_amd64 clean_elc_ppc64le clean_sg_ppc64le clean_og_ppc64le clean_asmc_ppc64le clean_ecv_ppc64le clean_elenart_ppc64le clean_elc_arm64 clean_sg_arm64 clean_og_arm64 clean_asmc_arm64 clean_ecv_arm64 clean_elenart_arm64 clean_elenasm_arm64 clean_elenasm_ppc64le clean_elenasm_amd64 clean_elenasm_i386 clean_elenavm_amd64 clean_elenavm_i386 clean_elenavm_ppc64le clean_elenavm_arm64 clean_elc_mac_amd64 clean_elc_mac_arm64 clean_elenart_mac_amd64 clean_elenart_mac_arm64 clean_elenavm_mac_arm64 clean_sg_mac_amd64 clean_sg_mac_arm64 clean_og_mac_amd64 clean_og_mac_arm64 clean_asmc_mac_amd64 clean_asmc_mac_arm64
+.PHONY: cross_elenart_win64 cross_elenart_win32 clean_cross_elenart_win64 clean_cross_elenart_win32 clean_elc_i386 clean_sg_i386 clean_og_i386 clean_asmc_i386 clean_ecv_i386 clean_elenart_i386 clean_elc_amd64 clean_sg_amd64 clean_og_amd64 clean_asmc_amd64 clean_ecv_amd64 clean_elenart_amd64 clean_elc_ppc64le clean_sg_ppc64le clean_og_ppc64le clean_asmc_ppc64le clean_ecv_ppc64le clean_elenart_ppc64le clean_elc_arm64 clean_sg_arm64 clean_og_arm64 clean_asmc_arm64 clean_ecv_arm64 clean_elenart_arm64 clean_elenasm_arm64 clean_elenasm_ppc64le clean_elenasm_amd64 clean_elenasm_i386 clean_elenavm_amd64 clean_elenavm_i386 clean_elenavm_ppc64le clean_elenavm_arm64 clean_elc_mac_amd64 clean_elc_mac_arm64 clean_elenart_mac_amd64 clean_elenart_mac_arm64 clean_elenavm_mac_arm64 clean_sg_mac_amd64 clean_sg_mac_arm64 clean_og_mac_amd64 clean_og_mac_arm64 clean_asmc_mac_amd64 clean_asmc_mac_arm64

--- a/scripts/aarch64/build_package_arm64.script
+++ b/scripts/aarch64/build_package_arm64.script
@@ -1,21 +1,15 @@
 #!/bin/bash
 RELEASE=elena-7.0.2.aarch64-linux
 
-mkdir -p ../lib60_64
-mkdir -p /usr/share/elena
-mkdir -p /etc/elena/
-mkdir -p /etc/elena/templates/
-mkdir -p /usr/lib/elena/core/aarch64/
-mkdir -p /usr/lib/elena/lib60_64
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
 
-cp ../../bin/libelenart60_64.so /usr/lib/elena/
-cp ../../bin/libelenasm60_64.so /usr/lib/elena/
-# cp ../bin/libelenavm.so /usr/lib/elena/
-cp ../../bin/elena64-cli /usr/bin/
-
-cp ../../bin/elc60.config /etc/elena/
-# cp ../bin/elenavm.config /etc/elena/
-cp ../../bin/templates/*.config /etc/elena/templates/
+mkdir -p ../../lib60_64
+mkdir -p ../../bin/aarch64
 
 echo compiling data files
 
@@ -69,13 +63,9 @@ else
   exit 1
 fi
 
-cp ../../dat/og/*.dat /usr/share/elena/
-cp ../../dat/sg/syntax60.dat /usr/share/elena
-cp ../../dat/sg/syntax67.dat /usr/share/elena
-
 echo compiling assembly files
 
-../../bin/asm64-cli -arm64 ../../asm/aarch64/core60.asm /usr/lib/elena/core/aarch64
+../../bin/asm64-cli -arm64 ../../asm/aarch64/core60.asm ../../bin/aarch64
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -85,7 +75,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -arm64 ../../asm/aarch64/core60_lnx.asm /usr/lib/elena/core/aarch64
+../../bin/asm64-cli -arm64 ../../asm/aarch64/core60_lnx.asm ../../bin/aarch64
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -95,7 +85,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -linux -arm64 ../../asm/aarch64/core60_client.asm /usr/lib/elena/core/aarch64 core60_lnx_client.bin
+../../bin/asm64-cli -linux -arm64 ../../asm/aarch64/core60_client.asm ../../bin/aarch64 core60_lnx_client.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -104,6 +94,31 @@ else
   echo "Failure" >&2
   exit 1
 fi
+
+echo installing binaries and configuration
+
+$SUDO mkdir -p /usr/share/elena
+$SUDO mkdir -p /etc/elena/
+$SUDO mkdir -p /etc/elena/templates/
+$SUDO mkdir -p /usr/lib/elena/core/aarch64/
+$SUDO mkdir -p /usr/lib/elena/lib60_64
+
+$SUDO cp --remove-destination ../../bin/libelenart60_64.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/libelenasm60_64.so /usr/lib/elena/
+# cp ../bin/libelenavm.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/elena64-cli /usr/bin/
+
+$SUDO cp --remove-destination ../../bin/elc60.config /etc/elena/
+# cp ../bin/elenavm.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/templates/*.config /etc/elena/templates/
+
+$SUDO cp --remove-destination ../../dat/og/*.dat /usr/share/elena/
+$SUDO cp --remove-destination ../../dat/sg/syntax60.dat /usr/share/elena
+$SUDO cp --remove-destination ../../dat/sg/syntax67.dat /usr/share/elena
+
+$SUDO cp --remove-destination ../../bin/aarch64/*.bin /usr/lib/elena/core/aarch64/
+
+echo compiling lib60 files
 
  ../../bin/asm64-cli -bc64 ../../src60/core/system.core_routines.esm ../../lib60_64
  ret=$?
@@ -125,8 +140,8 @@ fi
    echo .
  fi
 
- cp ../../lib60_64/*.nl /usr/lib/elena/lib60_64
- cp ../../lib60_64/*.dnl /usr/lib/elena/lib60_64 
+ $SUDO cp --remove-destination ../../lib60_64/*.nl /usr/lib/elena/lib60_64
+ $SUDO cp --remove-destination ../../lib60_64/*.dnl /usr/lib/elena/lib60_64
 
  elena64-cli ../../tests60/system_tests/system_tests.prj
  ret=$?
@@ -186,11 +201,12 @@ fi
 
  echo compiling core
 
- cp /usr/lib/elena/core/aarch64/*.bin ./$RELEASE/usr/lib/elena/core/aarch64/
+ cp ../../bin/aarch64/*.bin ./$RELEASE/usr/lib/elena/core/aarch64/
 
  echo compiling lib60
 
- cp /usr/lib/elena/lib60_64/*.* ./$RELEASE/usr/lib/elena/lib60_64/
+ cp ../../lib60_64/*.nl ./$RELEASE/usr/lib/elena/lib60_64/
+ cp ../../lib60_64/*.dnl ./$RELEASE/usr/lib/elena/lib60_64/
 
  cp -r ../../examples60 $RELEASE/usr/elena-lang
  cp -r ../../src60 $RELEASE/usr/elena-lang

--- a/scripts/amd64/build_package_amd64.script
+++ b/scripts/amd64/build_package_amd64.script
@@ -1,20 +1,14 @@
 #!/bin/bash
+
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
 mkdir -p ../../lib60_64
-mkdir -p /usr/share/elena
-mkdir -p /etc/elena/
-mkdir -p /etc/elena/templates/
-mkdir -p /usr/lib/elena/core/amd64/
-mkdir -p /usr/lib/elena/lib60_64
-
-cp ../../bin/libelenart60_64.so /usr/lib/elena/
-cp ../../bin/libelenasm60_64.so /usr/lib/elena/
-cp ../../bin/libelenavm60_64.so /usr/lib/elena/
-cp ../../bin/elena64-cli /usr/bin/
-
-cp ../../bin/elc60.config /etc/elena/
-cp ../../bin/elenavm60.config /etc/elena/
-cp ../../bin/elenart60.config /etc/elena/
-cp ../../bin/templates/*.config /etc/elena/templates/
+mkdir -p ../../bin/amd64
 
 echo compiling data files
 
@@ -68,16 +62,13 @@ else
   exit 1
 fi
 
-cp ../../dat/og/*.dat /usr/share/elena/
 cp ../../dat/og/*.dat ../../bin
-cp ../../dat/sg/syntax60.dat /usr/share/elena
 cp ../../dat/sg/syntax60.dat ../../bin
-cp ../../dat/sg/syntax67.dat /usr/share/elena
 cp ../../dat/sg/syntax67.dat ../../bin
 
 echo compiling assembly files
 
-../../bin/asm64-cli -linux -amd64 ../../asm/amd64/core60.asm /usr/lib/elena/core/amd64 core60_lnx.bin
+../../bin/asm64-cli -linux -amd64 ../../asm/amd64/core60.asm ../../bin/amd64 core60_lnx.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -87,7 +78,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -linux -amd64 ../../asm/amd64/corex60.asm /usr/lib/elena/core/amd64 corex60_lnx.bin
+../../bin/asm64-cli -linux -amd64 ../../asm/amd64/core60_client.asm ../../bin/amd64 core60_lnx_client.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -97,7 +88,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -linux -amd64 ../../asm/amd64/core60_client.asm /usr/lib/elena/core/amd64  core60_lnx_client.bin
+../../bin/asm64-cli -linux -amd64 ../../asm/amd64/corex60.asm ../../bin/amd64 corex60_lnx.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -106,6 +97,34 @@ else
   echo "Failure" >&2
   exit 1
 fi
+
+echo installing binaries and configuration
+
+$SUDO mkdir -p /usr/share/elena
+$SUDO mkdir -p /etc/elena/
+$SUDO mkdir -p /etc/elena/templates/
+$SUDO mkdir -p /usr/lib/elena/core/amd64/
+$SUDO mkdir -p /usr/lib/elena/lib60_64
+
+$SUDO cp --remove-destination ../../bin/libelenart60_64.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/libelenasm60_64.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/libelenavm60_64.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/elena64-cli /usr/bin/
+
+$SUDO cp --remove-destination ../../bin/elc60.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/elenavm60.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/elenart60.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/templates/*.config /etc/elena/templates/
+
+$SUDO cp --remove-destination ../../dat/og/*.dat /usr/share/elena/
+$SUDO cp --remove-destination ../../dat/sg/syntax60.dat /usr/share/elena
+$SUDO cp --remove-destination ../../dat/sg/syntax67.dat /usr/share/elena
+
+$SUDO cp --remove-destination ../../bin/amd64/core60_lnx.bin /usr/lib/elena/core/amd64/
+$SUDO cp --remove-destination ../../bin/amd64/core60_lnx_client.bin /usr/lib/elena/core/amd64/
+$SUDO cp --remove-destination ../../bin/amd64/corex60_lnx.bin /usr/lib/elena/core/amd64/
+
+echo compiling lib60 files
 
  ../../bin/asm64-cli -bc64 ../../src60/core/system.core_routines.esm ../../lib60_64
  ret=$?
@@ -127,5 +146,5 @@ fi
    echo .
  fi
 
- cp ../../lib60_64/*.nl /usr/lib/elena/lib60_64
- cp ../../lib60_64/*.dnl /usr/lib/elena/lib60_64 
+ $SUDO cp --remove-destination ../../lib60_64/*.nl /usr/lib/elena/lib60_64
+ $SUDO cp --remove-destination ../../lib60_64/*.dnl /usr/lib/elena/lib60_64

--- a/scripts/amd64/build_package_win64.script
+++ b/scripts/amd64/build_package_win64.script
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-mkdir -p ../../lib60_64_win
-mkdir -p /usr/lib/elena/lib60_64_win
-mkdir -p /usr/lib/elena/core/amd64/
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
 
-cp ../../bin/elena64-cli /usr/bin/
+mkdir -p ../../lib60_64_win
+mkdir -p ../../bin/amd64
 
 echo compiling assembly files
 
-../../bin/asm64-cli -windows -amd64 ../../asm/amd64/core60.asm /usr/lib/elena/core/amd64 core60_win.bin
+../../bin/asm64-cli -windows -amd64 ../../asm/amd64/core60.asm ../../bin/amd64 core60_win.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -18,7 +22,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -windows -amd64 ../../asm/amd64/corex60.asm /usr/lib/elena/core/amd64 corex60_win.bin
+../../bin/asm64-cli -windows -amd64 ../../asm/amd64/corex60.asm ../../bin/amd64 corex60_win.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -27,6 +31,16 @@ else
   echo "Failure" >&2
   exit 1
 fi
+
+echo installing binaries
+
+$SUDO mkdir -p /usr/lib/elena/core/amd64/
+$SUDO mkdir -p /usr/lib/elena/lib60_64_win
+
+$SUDO cp --remove-destination ../../bin/elena64-cli /usr/bin/
+
+$SUDO cp --remove-destination ../../bin/amd64/core60_win.bin /usr/lib/elena/core/amd64/
+$SUDO cp --remove-destination ../../bin/amd64/corex60_win.bin /usr/lib/elena/core/amd64/
 
 echo compiling lib60 files
 
@@ -50,7 +64,7 @@ echo compiling lib60 files
    echo .
  fi
 
- cp ../../lib60_64_win/*.nl /usr/lib/elena/lib60_64_win
- cp ../../lib60_64_win/*.dnl /usr/lib/elena/lib60_64_win
+ $SUDO cp --remove-destination ../../lib60_64_win/*.nl /usr/lib/elena/lib60_64_win
+ $SUDO cp --remove-destination ../../lib60_64_win/*.dnl /usr/lib/elena/lib60_64_win
 
- cp ../../bin/winstub.ex_ /usr/share/elena
+ $SUDO cp --remove-destination ../../bin/winstub.ex_ /usr/share/elena

--- a/scripts/amd64/local_build_package_amd64.script
+++ b/scripts/amd64/local_build_package_amd64.script
@@ -71,7 +71,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -linux -amd64 ../../asm/amd64/corex60.asm ../../bin/amd64 corex60_lnx.bin
+../../bin/asm64-cli -linux -amd64 ../../asm/amd64/core60_client.asm ../../bin/amd64  core60_lnx_client.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -81,7 +81,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -linux -amd64 ../../asm/amd64/core60_client.asm ../../bin/amd64  core60_lnx_client.bin
+../../bin/asm64-cli -linux -amd64 ../../asm/amd64/corex60.asm ../../bin/amd64 corex60_lnx.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -113,11 +113,8 @@ fi
    echo .
  fi
 
- mkdir -p /usr/lib/elena/
- ln -s $(realpath ../../bin/libelenart60_64.so) /usr/lib/elena/libelenart60_64.so
- ln -s $(realpath ../../bin/libelenavm60_64.so) /usr/lib/elena/libelenavm60_64.so
- ln -s $(realpath ../../bin/libelenasm60_64.so) /usr/lib/elena/libelenasm60_64.so
-
- mkdir -p /etc/elena/
- ln -s $(realpath ../../bin/elenart60.config) /etc/elena/elenart60.config
- ln -s $(realpath ../../bin/elenavm60.config) /etc/elena/elenavm60.config
+ if [ ! -e /usr/lib/elena/libelenart60_64.so ] || [ ! -e /etc/elena/elenart60.config ]
+ then
+   echo "local environment is not set up yet, running the one-time setup"
+   . setup_local_env.script
+ fi

--- a/scripts/amd64/local_runtests.script
+++ b/scripts/amd64/local_runtests.script
@@ -30,9 +30,28 @@
    echo .
  fi
 
- # ELENA has no wait with a deadline on Linux, so a hung MTA test has nothing of its own
- # to break it and would pin the job until the runner gives up
- timeout --signal=KILL 300s ../../tests60/mta_tests/mta_tests
+ # Keep an external watchdog for deadlocks involving the whole process.
+ timeout --signal=KILL 300s ../../tests60/mta_tests/mta_tests64
+ ret=$?
+ if [ $ret -eq 0 ]
+ then
+   echo .
+ else
+   echo "Failure" >&2
+   exit 1
+ fi
+
+ ../../bin/elena64-cli ../../tests60/async_tests/async_tests.prj
+ ret=$?
+ if [ $ret -eq 1 ]
+ then
+   echo "Failure" >&2
+   exit 1
+ else
+   echo .
+ fi
+
+ timeout --signal=KILL 300s ../../tests60/async_tests/async_tests
  ret=$?
  if [ $ret -eq 0 ]
  then

--- a/scripts/amd64/setup_local_env.script
+++ b/scripts/amd64/setup_local_env.script
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
+$SUDO mkdir -p /usr/lib/elena/
+$SUDO ln -sf $(realpath ../../bin/libelenart60_64.so) /usr/lib/elena/libelenart60_64.so
+$SUDO ln -sf $(realpath ../../bin/libelenavm60_64.so) /usr/lib/elena/libelenavm60_64.so
+$SUDO ln -sf $(realpath ../../bin/libelenasm60_64.so) /usr/lib/elena/libelenasm60_64.so
+
+$SUDO mkdir -p /etc/elena/
+$SUDO ln -sf $(realpath ../../bin/elenart60.config) /etc/elena/elenart60.config
+$SUDO ln -sf $(realpath ../../bin/elenavm60.config) /etc/elena/elenavm60.config

--- a/scripts/amd64/uninstall_amd64.script
+++ b/scripts/amd64/uninstall_amd64.script
@@ -1,41 +1,48 @@
 #!/bin/bash
 
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
 read -p "You are going to uninstall ELENA Language. Are you sure? " -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
 
   echo removing ELENA shared libraries
-  rm /usr/lib/elena/libelenart60_64.so
-  rm /usr/lib/elena/libelenasm60_64.so
-  rm /usr/lib/elena/libelenavm60_64.so
+  $SUDO rm -f /usr/lib/elena/libelenart60_64.so
+  $SUDO rm -f /usr/lib/elena/libelenasm60_64.so
+  $SUDO rm -f /usr/lib/elena/libelenavm60_64.so
 
   echo removing ELENA compiler executable
-  rm /usr/bin/elena64-cli
+  $SUDO rm -f /usr/bin/elena64-cli
 
   echo removing ELENA configuration files
 
-  rm /etc/elena/templates/*.config
-  rmdir /etc/elena/templates
+  $SUDO rm -f /etc/elena/templates/*.config
+  $SUDO rmdir --ignore-fail-on-non-empty /etc/elena/templates
 
-  rm /etc/elena/*.config
-  rmdir /etc/elena
+  $SUDO rm -f /etc/elena/*.config
+  $SUDO rmdir --ignore-fail-on-non-empty /etc/elena
 
   echo removing ELENA data files
-  rm /usr/share/elena/*.dat
-  rmdir /usr/share/elena
+  $SUDO rm -f /usr/share/elena/*.dat
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/share/elena
 
   echo removing ELENA API compiled modules
 
-  rm /usr/lib/elena/core/amd64/*.bin
-  rmdir /usr/lib/elena/core/amd64
-  rmdir /usr/lib/elena/core
+  $SUDO rm -f /usr/lib/elena/core/amd64/*.bin
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena/core/amd64
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena/core
 
-  rm /usr/lib/elena/lib60_64/*.nl
-  rm /usr/lib/elena/lib60_64/*.dnl
+  $SUDO rm -f /usr/lib/elena/lib60_64/*.nl
+  $SUDO rm -f /usr/lib/elena/lib60_64/*.dnl
 
-  rmdir /usr/lib/elena/lib60_64
-  rmdir /usr/lib/elena
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena/lib60_64
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena
 
 fi
 

--- a/scripts/i386/build_package_i386.script
+++ b/scripts/i386/build_package_i386.script
@@ -1,28 +1,14 @@
 #!/bin/bash
 
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
 mkdir -p ../../lib60
-mkdir -p /usr/share/elena
-mkdir -p /etc/elena/
-mkdir -p /etc/elena/templates/
-mkdir -p /etc/elena/scripts/
-mkdir -p /usr/lib/elena/core/x32/
-mkdir -p /usr/lib/elena/core/amd64/
-mkdir -p /usr/lib/elena/lib60
-
-cp ../../bin/libelenart60.so /usr/lib/elena/
-cp ../../bin/libelenasm60.so /usr/lib/elena/
-cp ../../bin/libelenavm60.so /usr/lib/elena/
-cp ../../bin/elena-cli /usr/bin/
-
-ldconfig /usr/lib/elena
-
-cp ../../bin/elc60.config /etc/elena/
-cp ../../bin/elenart60.config /etc/elena/
-cp ../../bin/elenavm60.config /etc/elena/
-cp ../../bin/elt60.es /etc/elena/
-cp ../../bin/templates/*.config /etc/elena/templates/
-cp ../../bin/scripts/*.es /etc/elena/scripts/
-cp ../../bin/scripts/*.elt /etc/elena/scripts/
+mkdir -p ../../bin/x32
 
 echo compiling data files
 
@@ -76,16 +62,13 @@ else
   exit 1
 fi
 
-cp ../../dat/og/*.dat /usr/share/elena/
 cp ../../dat/og/*.dat ../../bin
-cp ../../dat/sg/syntax60.dat /usr/share/elena
 cp ../../dat/sg/syntax60.dat ../../bin
-cp ../../dat/sg/syntax67.dat /usr/share/elena
 cp ../../dat/sg/syntax67.dat ../../bin
 
 echo compiling assembly files
 
-../../bin/asm-cli -linux -x86 ../../asm/x32/core60.asm /usr/lib/elena/core/x32 core60_lnx.bin
+../../bin/asm-cli -linux -x86 ../../asm/x32/core60.asm ../../bin/x32 core60_lnx.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -95,7 +78,7 @@ else
   exit 1
 fi
 
-../../bin/asm-cli -linux -x86 ../../asm/x32/corex60.asm /usr/lib/elena/core/x32 corex60_lnx.bin
+../../bin/asm-cli -linux -x86 ../../asm/x32/corex60.asm ../../bin/x32 corex60_lnx.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -105,7 +88,7 @@ else
   exit 1
 fi
 
-../../bin/asm-cli -linux -x86 ../../asm/x32/core60_client.asm /usr/lib/elena/core/x32 core60_lnx_client.bin
+../../bin/asm-cli -linux -x86 ../../asm/x32/core60_client.asm ../../bin/x32 core60_lnx_client.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -114,6 +97,38 @@ else
   echo "Failure" >&2
   exit 1
 fi
+
+echo installing binaries and configuration
+
+$SUDO mkdir -p /usr/share/elena
+$SUDO mkdir -p /etc/elena/
+$SUDO mkdir -p /etc/elena/templates/
+$SUDO mkdir -p /etc/elena/scripts/
+$SUDO mkdir -p /usr/lib/elena/core/x32/
+$SUDO mkdir -p /usr/lib/elena/lib60
+
+$SUDO cp --remove-destination ../../bin/libelenart60.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/libelenasm60.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/libelenavm60.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/elena-cli /usr/bin/
+
+$SUDO ldconfig /usr/lib/elena
+
+$SUDO cp --remove-destination ../../bin/elc60.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/elenart60.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/elenavm60.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/elt60.es /etc/elena/
+$SUDO cp --remove-destination ../../bin/templates/*.config /etc/elena/templates/
+$SUDO cp --remove-destination ../../bin/scripts/*.es /etc/elena/scripts/
+$SUDO cp --remove-destination ../../bin/scripts/*.elt /etc/elena/scripts/
+
+$SUDO cp --remove-destination ../../dat/og/*.dat /usr/share/elena/
+$SUDO cp --remove-destination ../../dat/sg/syntax60.dat /usr/share/elena
+$SUDO cp --remove-destination ../../dat/sg/syntax67.dat /usr/share/elena
+
+$SUDO cp --remove-destination ../../bin/x32/core60_lnx.bin /usr/lib/elena/core/x32/
+$SUDO cp --remove-destination ../../bin/x32/corex60_lnx.bin /usr/lib/elena/core/x32/
+$SUDO cp --remove-destination ../../bin/x32/core60_lnx_client.bin /usr/lib/elena/core/x32/
 
 echo compiling lib60 files
 
@@ -137,8 +152,8 @@ echo compiling lib60 files
    echo .
  fi
 
- cp ../../lib60/*.nl /usr/lib/elena/lib60
- cp ../../lib60/*.dnl /usr/lib/elena/lib60
+ $SUDO cp --remove-destination ../../lib60/*.nl /usr/lib/elena/lib60
+ $SUDO cp --remove-destination ../../lib60/*.dnl /usr/lib/elena/lib60
 
  elena-cli ../../tests60/system_tests/system_tests.prj
  ret=$?

--- a/scripts/i386/build_package_win32.script
+++ b/scripts/i386/build_package_win32.script
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-mkdir -p /usr/lib/elena/core/x32/
-mkdir -p ../../lib60_win
-mkdir -p /usr/lib/elena/lib60_win
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
 
-cp ../../bin/elena-cli /usr/bin/
+mkdir -p ../../lib60_win
+mkdir -p ../../bin/x32
 
 echo compiling assembly files
 
-../../bin/asm-cli -windows -x86 ../../asm/x32/core60.asm /usr/lib/elena/core/x32 core60_win.bin
+../../bin/asm-cli -windows -x86 ../../asm/x32/core60.asm ../../bin/x32 core60_win.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -18,7 +22,7 @@ else
   exit 1
 fi
 
-../../bin/asm-cli -windows -x86 ../../asm/x32/corex60.asm /usr/lib/elena/core/x32 corex60_win.bin
+../../bin/asm-cli -windows -x86 ../../asm/x32/corex60.asm ../../bin/x32 corex60_win.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -27,6 +31,16 @@ else
   echo "Failure" >&2
   exit 1
 fi
+
+echo installing binaries
+
+$SUDO mkdir -p /usr/lib/elena/core/x32/
+$SUDO mkdir -p /usr/lib/elena/lib60_win
+
+$SUDO cp --remove-destination ../../bin/elena-cli /usr/bin/
+
+$SUDO cp --remove-destination ../../bin/x32/core60_win.bin /usr/lib/elena/core/x32/
+$SUDO cp --remove-destination ../../bin/x32/corex60_win.bin /usr/lib/elena/core/x32/
 
 echo compiling lib60 files
 
@@ -50,8 +64,7 @@ echo compiling lib60 files
    echo .
  fi
 
- cp ../../lib60_win/*.nl /usr/lib/elena/lib60_win
- cp ../../lib60_win/*.dnl /usr/lib/elena/lib60_win
+ $SUDO cp --remove-destination ../../lib60_win/*.nl /usr/lib/elena/lib60_win
+ $SUDO cp --remove-destination ../../lib60_win/*.dnl /usr/lib/elena/lib60_win
 
- cp ../../bin/winstub.ex_ /usr/share/elena
-
+ $SUDO cp --remove-destination ../../bin/winstub.ex_ /usr/share/elena

--- a/scripts/i386/local_build_package_i386.script
+++ b/scripts/i386/local_build_package_i386.script
@@ -115,11 +115,8 @@ fi
    echo .
  fi
 
- mkdir -p /usr/lib/elena/
- ln -s $(realpath ../../bin/libelenart60.so) /usr/lib/elena/libelenart60.so
- ln -s $(realpath ../../bin/libelenavm60.so) /usr/lib/elena/libelenavm60.so
- ln -s $(realpath ../../bin/libelenasm60.so) /usr/lib/elena/libelenasm60.so
-
- mkdir -p /etc/elena/
- ln -s $(realpath ../../bin/local.elenart60.config) /etc/elena/elenart60.config
- ln -s $(realpath ../../bin/local.elenavm60.config) /etc/elena/elenavm60.config
+ if [ ! -e /usr/lib/elena/libelenart60.so ] || [ ! -e /etc/elena/elenart60.config ]
+ then
+   echo "local environment is not set up yet, running the one-time setup"
+   . setup_local_env.script
+ fi

--- a/scripts/i386/local_build_package_win32.script
+++ b/scripts/i386/local_build_package_win32.script
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 mkdir -p ../../lib60_win
+mkdir -p ../../bin/x32
 
 echo compiling assembly files
 
-../../bin/asm-cli -windows -x86 ../../asm/x32/core60.asm /usr/lib/elena/core/x32 core60_win.bin
+../../bin/asm-cli -windows -x86 ../../asm/x32/core60.asm ../../bin/x32 core60_win.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -14,7 +15,7 @@ else
   exit 1
 fi
 
-../../bin/asm-cli -windows -x86 ../../asm/x32/corex60.asm /usr/lib/elena/core/x32 corex60_win.bin
+../../bin/asm-cli -windows -x86 ../../asm/x32/corex60.asm ../../bin/x32 corex60_win.bin
 ret=$?
 if [ $ret -eq 0 ]
 then

--- a/scripts/i386/local_runtests.script
+++ b/scripts/i386/local_runtests.script
@@ -30,9 +30,28 @@
    echo .
  fi
 
- # ELENA has no wait with a deadline on Linux, so a hung MTA test has nothing of its own
- # to break it and would pin the job until the runner gives up
+ # Keep an external watchdog for deadlocks involving the whole process.
  timeout --signal=KILL 300s ../../tests60/mta_tests/mta_tests
+ ret=$?
+ if [ $ret -eq 0 ]
+ then
+   echo .
+ else
+   echo "Failure" >&2
+   exit 1
+ fi
+
+ ../../bin/elena-cli ../../tests60/async_tests/async_tests.prj
+ ret=$?
+ if [ $ret -eq 1 ]
+ then
+   echo "Failure" >&2
+   exit 1
+ else
+   echo .
+ fi
+
+ timeout --signal=KILL 300s ../../tests60/async_tests/async_tests
  ret=$?
  if [ $ret -eq 0 ]
  then

--- a/scripts/i386/setup_local_env.script
+++ b/scripts/i386/setup_local_env.script
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
+$SUDO mkdir -p /usr/lib/elena/
+$SUDO ln -sf $(realpath ../../bin/libelenart60.so) /usr/lib/elena/libelenart60.so
+$SUDO ln -sf $(realpath ../../bin/libelenavm60.so) /usr/lib/elena/libelenavm60.so
+$SUDO ln -sf $(realpath ../../bin/libelenasm60.so) /usr/lib/elena/libelenasm60.so
+
+$SUDO mkdir -p /etc/elena/
+$SUDO ln -sf $(realpath ../../bin/local.elenart60.config) /etc/elena/elenart60.config
+$SUDO ln -sf $(realpath ../../bin/local.elenavm60.config) /etc/elena/elenavm60.config

--- a/scripts/i386/uninstall_i386.script
+++ b/scripts/i386/uninstall_i386.script
@@ -1,40 +1,54 @@
 #!/bin/bash
 
-echo removing ELENA shared libraries
-rm /usr/lib/elena/libelenart60.so
-rm /usr/lib/elena/libelenasm60.so
-rm /usr/lib/elena/libelenavm60.so
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
 
-echo removing ELENA compiler executable
-rm /usr/bin/elena-cli
+read -p "You are going to uninstall ELENA Language. Are you sure? " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
 
-echo removing ELENA configuration files
+  echo removing ELENA shared libraries
+  $SUDO rm -f /usr/lib/elena/libelenart60.so
+  $SUDO rm -f /usr/lib/elena/libelenasm60.so
+  $SUDO rm -f /usr/lib/elena/libelenavm60.so
 
-rm /etc/elena/templates/*.config
-rmdir /etc/elena/templates
+  echo removing ELENA compiler executable
+  $SUDO rm -f /usr/bin/elena-cli
 
-rm /etc/elena/scripts/*.es
-rm /etc/elena/scripts/*.elt
-rmdir /etc/elena/scripts
+  echo removing ELENA configuration files
 
-rm /etc/elena/*.config
-rm /etc/elena/*.es
-rmdir /etc/elena
+  $SUDO rm -f /etc/elena/templates/*.config
+  $SUDO rmdir --ignore-fail-on-non-empty /etc/elena/templates
 
-echo removing ELENA data files
-rm /usr/share/elena/*.dat
-rmdir /usr/share/elena
+  $SUDO rm -f /etc/elena/scripts/*.es
+  $SUDO rm -f /etc/elena/scripts/*.elt
+  $SUDO rmdir --ignore-fail-on-non-empty /etc/elena/scripts
 
-echo removing ELENA API compiled modules
+  $SUDO rm -f /etc/elena/*.config
+  $SUDO rm -f /etc/elena/*.es
+  $SUDO rmdir --ignore-fail-on-non-empty /etc/elena
 
-rm /usr/lib/elena/core/x32/*.bin
-rmdir /usr/lib/elena/core/x32
-rmdir /usr/lib/elena/core
+  echo removing ELENA data files
+  $SUDO rm -f /usr/share/elena/*.dat
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/share/elena
 
-rm /usr/lib/elena/lib60/*.nl
-rm /usr/lib/elena/lib60/*.dnl
+  echo removing ELENA API compiled modules
 
-rmdir /usr/lib/elena/lib60
-rmdir /usr/lib/elena
+  $SUDO rm -f /usr/lib/elena/core/x32/*.bin
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena/core/x32
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena/core
+
+  $SUDO rm -f /usr/lib/elena/lib60/*.nl
+  $SUDO rm -f /usr/lib/elena/lib60/*.dnl
+
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena/lib60
+  $SUDO rmdir --ignore-fail-on-non-empty /usr/lib/elena
+
+fi
 
 exit 0

--- a/scripts/local_runwinetests.script
+++ b/scripts/local_runwinetests.script
@@ -1,0 +1,52 @@
+#!/bin/bash
+# stages the cross-built test suites with the mingw runtime and runs them under Wine
+# expects: the *.exe files (elena*-cli -xtwin64/-xtwin32) and
+# bin/elenart60_64.dll / bin/elenart60.dll (make cross_elenart_win64 / _win32)
+
+STAGE=../temp/wine_mta
+ret_total=0
+
+run_one()
+{
+   arch=$1
+   dir=$2
+   exe=$3
+   dll=$4
+
+   if [ ! -f ../tests60/$dir/$exe ] || [ ! -f ../bin/$dll ]
+   then
+      echo "$arch $dir: skipped, $exe or $dll not built"
+      return 0
+   fi
+
+   mkdir -p $STAGE/$arch/$dir
+   cp ../tests60/$dir/$exe $STAGE/$arch/$dir/
+   cp ../bin/$dll $STAGE/$arch/$dir/
+
+   echo "=== $arch $dir ==="
+   ( cd $STAGE/$arch/$dir && WINEDEBUG=-all timeout --signal=KILL 30s wine ./$exe )
+   ret=$?
+   if [ $ret -eq 0 ]
+   then
+      echo "$arch $dir: passed"
+   elif [ $ret -eq 137 ]
+   then
+      echo "$arch $dir: HANG, killed by the watchdog. Attach with:" >&2
+      echo "  (cd $STAGE/$arch/$dir && wine ./$exe &) ; winedbg" >&2
+      ret_total=1
+   else
+      echo "$arch $dir: failed with $ret" >&2
+      ret_total=1
+   fi
+}
+
+run_one x64 system_tests system_tests64.exe elenart60_64.dll
+run_one x86 system_tests system_tests.exe elenart60.dll
+
+run_one x64 mta_tests mta_tests64.exe elenart60_64.dll
+run_one x86 mta_tests mta_tests.exe elenart60.dll
+
+run_one x64 async_tests async_tests64.exe elenart60_64.dll
+run_one x86 async_tests async_tests.exe elenart60.dll
+
+exit $ret_total

--- a/scripts/ppc64le/build_package_ppc64le.script
+++ b/scripts/ppc64le/build_package_ppc64le.script
@@ -1,21 +1,15 @@
 #!/bin/bash
 RELEASE=elena-7.0.2.ppc64le-linux
 
-mkdir -p ../lib60_64
-mkdir -p /usr/share/elena
-mkdir -p /etc/elena/
-mkdir -p /etc/elena/templates/
-mkdir -p /usr/lib/elena/core/ppc64le/
-mkdir -p /usr/lib/elena/lib60_64
+if [ "$(id -u)" -ne 0 ]
+then
+  SUDO=sudo
+else
+  SUDO=
+fi
 
-cp ../../bin/libelenart60_64.so /usr/lib/elena/
-cp ../../bin/libelenasm60_64.so /usr/lib/elena/
-# cp ../bin/libelenavm.so /usr/lib/elena/
-cp ../../bin/elena64-cli /usr/bin/
-
-cp ../../bin/elc60.config /etc/elena/
-# cp ../bin/elenavm.config /etc/elena/
-cp ../../bin/templates/*.config /etc/elena/templates/
+mkdir -p ../../lib60_64
+mkdir -p ../../bin/ppc64le
 
 echo compiling data files
 
@@ -69,13 +63,9 @@ else
   exit 1
 fi
 
-cp ../../dat/og/*.dat /usr/share/elena/
-cp ../../dat/sg/syntax60.dat /usr/share/elena
-cp ../../dat/sg/syntax67.dat /usr/share/elena
-
 echo compiling assembly files
 
-../../bin/asm64-cli -ppc64le ../../asm/ppc64le/core60.asm /usr/lib/elena/core/ppc64le
+../../bin/asm64-cli -ppc64le ../../asm/ppc64le/core60.asm ../../bin/ppc64le
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -85,7 +75,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -ppc64le ../../asm/ppc64le/core60_lnx.asm /usr/lib/elena/core/ppc64le
+../../bin/asm64-cli -ppc64le ../../asm/ppc64le/core60_lnx.asm ../../bin/ppc64le
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -95,7 +85,7 @@ else
   exit 1
 fi
 
-../../bin/asm64-cli -linux -ppc64le ../../asm/ppc64le/core60_client.asm /usr/lib/elena/core/ppc64le core60_lnx_client.bin
+../../bin/asm64-cli -linux -ppc64le ../../asm/ppc64le/core60_client.asm ../../bin/ppc64le core60_lnx_client.bin
 ret=$?
 if [ $ret -eq 0 ]
 then
@@ -105,17 +95,30 @@ else
   exit 1
 fi
 
-# ../bin/elena-asm2binx ../asm/x32/coreapi.asm /usr/lib/elena/core/x32
-# ret=$?
-# if [ $ret -eq 0 ]
-# then
-#   echo .
-# else
-#   echo "Failure" >&2
-#   exit 1
-# fi
-#
-# echo compiling lib50 files
+echo installing binaries and configuration
+
+$SUDO mkdir -p /usr/share/elena
+$SUDO mkdir -p /etc/elena/
+$SUDO mkdir -p /etc/elena/templates/
+$SUDO mkdir -p /usr/lib/elena/core/ppc64le/
+$SUDO mkdir -p /usr/lib/elena/lib60_64
+
+$SUDO cp --remove-destination ../../bin/libelenart60_64.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/libelenasm60_64.so /usr/lib/elena/
+# cp ../bin/libelenavm.so /usr/lib/elena/
+$SUDO cp --remove-destination ../../bin/elena64-cli /usr/bin/
+
+$SUDO cp --remove-destination ../../bin/elc60.config /etc/elena/
+# cp ../bin/elenavm.config /etc/elena/
+$SUDO cp --remove-destination ../../bin/templates/*.config /etc/elena/templates/
+
+$SUDO cp --remove-destination ../../dat/og/*.dat /usr/share/elena/
+$SUDO cp --remove-destination ../../dat/sg/syntax60.dat /usr/share/elena
+$SUDO cp --remove-destination ../../dat/sg/syntax67.dat /usr/share/elena
+
+$SUDO cp --remove-destination ../../bin/ppc64le/*.bin /usr/lib/elena/core/ppc64le/
+
+echo compiling lib60 files
 
  ../../bin/asm64-cli -bc64 ../../src60/core/system.core_routines.esm ../../lib60_64
  ret=$?
@@ -137,8 +140,8 @@ fi
    echo .
  fi
 
- cp ../../lib60_64/*.nl /usr/lib/elena/lib60_64
- cp ../../lib60_64/*.dnl /usr/lib/elena/lib60_64 
+ $SUDO cp --remove-destination ../../lib60_64/*.nl /usr/lib/elena/lib60_64
+ $SUDO cp --remove-destination ../../lib60_64/*.dnl /usr/lib/elena/lib60_64
 
  elena64-cli ../../tests60/system_tests/system_tests.prj
  ret=$?
@@ -198,11 +201,12 @@ fi
 
  echo compiling core
 
- cp /usr/lib/elena/core/ppc64le/*.bin ./$RELEASE/usr/lib/elena/core/ppc64le/
+ cp ../../bin/ppc64le/*.bin ./$RELEASE/usr/lib/elena/core/ppc64le/
 
  echo compiling lib60
 
- cp /usr/lib/elena/lib60_64/*.* ./$RELEASE/usr/lib/elena/lib60_64/
+ cp ../../lib60_64/*.nl ./$RELEASE/usr/lib/elena/lib60_64/
+ cp ../../lib60_64/*.dnl ./$RELEASE/usr/lib/elena/lib60_64/
 
  cp -r ../../examples60 $RELEASE/usr/elena-lang
  cp -r ../../src60 $RELEASE/usr/elena-lang


### PR DESCRIPTION
# Description

This PR improves the Linux build workflow and adds MinGW cross-build support for Win32 and Win64 runtimes.

It also adds one-time local environment setup scripts, safer install/uninstall handling, native test runners for i386 and amd64, and a Wine runner for cross-built Windows tests.

The build scripts now generate artifacts locally before installing them, making development builds easier to reproduce without repeatedly copying runtime files.

Optional dependencies:

- MinGW-w64 for Windows cross-builds
- Wine for running Windows tests on Linux

Tested with:

- Linux i386 and amd64: system_tests, mta_tests, async_tests
- MinGW: Win32 and Win64 runtime DLL builds
- Wine i386: all three test suites

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)