### PR TITLE
Fix awaited expressions in async returns

### DIFF
--- a/doc/whatsnew
+++ b/doc/whatsnew
@@ -14,6 +14,7 @@
   - [FIXED] critical error : an unresolved forward crashed the compiler instead of being reported
   - [REDUX] redesigning include / exclude, move operation about marking thread as non-collectable to system 8 / system 9
   - [ADDED] Supporting System V ABI for x86_64
+  - [FIXED] async methods returning expressions with await operations
 
 - VM
 

--- a/elenasrc3/elc/compiler.cpp
+++ b/elenasrc3/elc/compiler.cpp
@@ -14349,15 +14349,11 @@ ObjectInfo Compiler::Expression :: compileAsyncOperation(SyntaxNode node, ref_t 
    ObjectInfo contextField = smScope->mapContextField();
    ObjectInfo currentField = smScope->mapCurrentField();
 
-   ObjectInfo exprVal = {};
-   if (retMode)
-      exprVal = compile(node.firstChild(), targetRef, EAttr::AsyncOp | EAttr::StackUnsafe);
+   ObjectInfo exprVal = compile(node.firstChild(), retMode ? targetRef : currentField.typeInfo.typeRef,
+      EAttr::AsyncOp | EAttr::StackUnsafe);
 
    writer->newNode(BuildKey::YieldingOp, -scope.moduleScope->ptrSize);
    writer->newNode(BuildKey::Tape);
-
-   if (!retMode)
-      exprVal = compile(node.firstChild(), currentField.typeInfo.typeRef, EAttr::AsyncOp | EAttr::StackUnsafe);
 
    // !! HOTFIX - add the temporal boxed variable whic hrequires unboxing as yield variables (to be resued)
    for (auto it = scope.tempLocals.start(); !it.eof(); ++it) {

--- a/elenasrc3/elc/compiler.cpp
+++ b/elenasrc3/elc/compiler.cpp
@@ -14349,10 +14349,15 @@ ObjectInfo Compiler::Expression :: compileAsyncOperation(SyntaxNode node, ref_t 
    ObjectInfo contextField = smScope->mapContextField();
    ObjectInfo currentField = smScope->mapCurrentField();
 
+   ObjectInfo exprVal = {};
+   if (retMode)
+      exprVal = compile(node.firstChild(), targetRef, EAttr::AsyncOp | EAttr::StackUnsafe);
+
    writer->newNode(BuildKey::YieldingOp, -scope.moduleScope->ptrSize);
    writer->newNode(BuildKey::Tape);
 
-   ObjectInfo exprVal = compile(node.firstChild(), retMode ? targetRef : currentField.typeInfo.typeRef, EAttr::AsyncOp | EAttr::StackUnsafe);
+   if (!retMode)
+      exprVal = compile(node.firstChild(), currentField.typeInfo.typeRef, EAttr::AsyncOp | EAttr::StackUnsafe);
 
    // !! HOTFIX - add the temporal boxed variable whic hrequires unboxing as yield variables (to be resued)
    for (auto it = scope.tempLocals.start(); !it.eof(); ++it) {

--- a/tests60/async_tests/basic.l
+++ b/tests60/async_tests/basic.l
@@ -68,22 +68,27 @@ class AsyncAwaitScenarios
       ^ result
    }
 
-   async Task<int> sumAwaitedValuesAsync(int value)
+   async Task<int> returnAwaitedValueAsync(Task<int> blocker)
+   {
+      ^ :await blocker
+   }
+
+   async Task<int> sumAwaitedValuesViaLocalAsync(int value)
    {
       int result := (:await delayedValueAsync(value)) + (:await delayedValueAsync(value + 1));
 
       ^ result
    }
 
-   // Multiple awaits work when the result is stored first
-   // Returning the same expression directly leaves the generated task pending...
-   // It looks like the return lowering wraps an expression that already contains suspension points
-   // Somewhere in the final resume the result is not forwarded and the generated promise stays open
-   // Saving it in a local separates the await step from the return step... which is why the version above works...
-   // async Task<int> sumAwaitedValuesAsync(int value)
-   // {
-   //    ^ ((:await delayedValueAsync(value)) + (:await delayedValueAsync(value + 1)));
-   // }
+   async Task<int> sumAwaitedValuesAsync(int value)
+   {
+      ^ (:await delayedValueAsync(value)) + (:await delayedValueAsync(value + 1))
+   }
+
+   async Task<int> sumThreeAwaitedValuesAsync(int value)
+   {
+      ^ (:await delayedValueAsync(value)) + (:await delayedValueAsync(value + 1)) + (:await delayedValueAsync(value + 2))
+   }
 
    async Task<int> chainedAsync(int value)
    {
@@ -140,16 +145,26 @@ public awaitValueThenReturnTest() : testCase()
    AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
 
    Task<int> pending := scenarios.awaitValueThenReturnAsync(blocker);
+   Task<int> directPending := scenarios.returnAwaitedValueAsync(blocker);
+   ManualResetEvent directCompleted := ManualResetEvent.new();
+   directPending.continueWith((Task task){ directCompleted.set() });
+
    Assert.ifFalse(pending.IsCompleted);
+   Assert.ifFalse(directPending.IsCompleted);
 
    gate.set();
    Assert.ifEqual(pending.Result, 42);
    Assert.ifTrue(pending.IsCompletedSuccessfully);
+   Assert.ifTrue(directCompleted.wait(5000));
+   Assert.ifEqual(directPending.Result, 42);
+   Assert.ifTrue(directPending.IsCompletedSuccessfully);
 
    // A completed antecedent follows the synchronous fast path.
    Task<int> completed := class Task<int>.fromResult(7);
    Assert.ifEqual(scenarios.awaitValueThenReturnAsync(completed).Result, 7);
+   Assert.ifEqual(scenarios.returnAwaitedValueAsync(completed).Result, 7);
 
+   directCompleted.close();
    gate.close();
 
    Console.write(".")
@@ -160,7 +175,24 @@ public multipleAwaitsInExpressionTest() : testCase()
    AsyncAwaitScenarios scenarios := new AsyncAwaitScenarios();
 
    // The first result must survive while the second await is suspended.
-   Assert.ifEqual(scenarios.sumAwaitedValuesAsync(20).Result, 41);
+   Assert.ifEqual(scenarios.sumAwaitedValuesViaLocalAsync(20).Result, 41);
+
+   Task<int> direct := scenarios.sumAwaitedValuesAsync(20);
+   ManualResetEvent completed := ManualResetEvent.new();
+   direct.continueWith((Task task){ completed.set() });
+
+   Assert.ifTrue(completed.wait(5000));
+   Assert.ifEqual(direct.Result, 41);
+
+   completed.reset();
+
+   Task<int> directThree := scenarios.sumThreeAwaitedValuesAsync(20);
+   directThree.continueWith((Task task){ completed.set() });
+
+   Assert.ifTrue(completed.wait(5000));
+   Assert.ifEqual(directThree.Result, 63);
+
+   completed.close();
 
    Console.write(".")
 }


### PR DESCRIPTION
# Description

Fixes async methods returning expressions containing one or multiple :await operations. Previously, the generated task could remain pending instead of completing.

 Adds regression tests and updates whatsnew.

 Tested on Linux i386 and amd64 with:

 - async_tests
 - system_tests
 - mta_tests

 ## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] This change requires a documentation update