### PR TITLE
Add cancellation token support for tasks and async operations

### DIFF
--- a/doc/whatsnew
+++ b/doc/whatsnew
@@ -42,6 +42,7 @@
   - [FIXED] async / await completion and exception propagation
   - [REMOVED] system'Indexer, system'Indexer<T> interfaces are no longer supported
   - [REDUX] system'Indexable, system'Indexable<T> interfaces are modified
+  - [ADDED] cancellation tokens and cooperative task cancellation
 
 - Scripts
 

--- a/src60/system/system.linux.prj
+++ b/src60/system/system.linux.prj
@@ -137,6 +137,7 @@
        <include>threading/events.l</include>
        <include>threading/blockinglists.l</include>
        <include>threading/threadpool.l</include>
+       <include>threading/cancellation.l</include>
        <include>threading/tasks.l</include>
        <include>threading/templates.l</include>
        <include>threading/template_tests.l</include>

--- a/src60/system/system.mac.prj
+++ b/src60/system/system.mac.prj
@@ -97,6 +97,7 @@
        <include>threading/events.l</include>
        <include>threading/blockinglists.l</include>
        <include>threading/threadpool.l</include>
+       <include>threading/cancellation.l</include>
        <include>threading/tasks.l</include>
        <include>threading/templates.l</include>
        <include>threading/template_tests.l</include>

--- a/src60/system/system.prj
+++ b/src60/system/system.prj
@@ -111,6 +111,7 @@
             <include>threading\events.l</include>
             <include>threading\blockinglists.l</include>
             <include>threading\threadpool.l</include>
+            <include>threading\cancellation.l</include>
             <include>threading\tasks.l</include>
             <include>threading\templates.l</include>
             <include>threading\template_tests.l</include>

--- a/src60/system/threading/cancellation.l
+++ b/src60/system/threading/cancellation.l
@@ -1,0 +1,228 @@
+import system'collections;
+
+public sealed class CancellationTokenRegistration
+{
+   CancellationTokenSource? _source;
+   Func?                    _action;
+
+   internal constructor new()
+   {
+   }
+
+   internal constructor new(CancellationTokenSource source, Func action)
+   {
+      _source := source;
+      _action := action
+   }
+
+   internal Func? takeAction()
+   {
+      Func? action := nil;
+      lock(self) {
+         action := _action;
+         _action := nil;
+         _source := nil
+      };
+
+      ^ action
+   }
+
+   close()
+   {
+      CancellationTokenSource? source := nil;
+      lock(self) {
+         source := _source;
+         _source := nil;
+         _action := nil
+      };
+
+      if:not:nil(source)
+         source!.unregister(self)
+   }
+}
+
+public sealed class CancellationToken
+{
+   CancellationTokenSource? _source;
+
+   static CancellationToken _none;
+
+   static constructor()
+   {
+      _none := new CancellationToken()
+   }
+
+   internal constructor new()
+   {
+   }
+
+   internal constructor new(CancellationTokenSource source)
+   {
+      _source := source
+   }
+
+   static CancellationToken None
+      = _none;
+
+   bool CanBeCanceled
+      = _source != nil;
+
+   bool IsCancellationRequested
+      = _source?.IsCancellationRequested ?? false;
+
+   CancellationTokenRegistration register(Func action)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      CancellationTokenSource? source := _source;
+      if (source == nil)
+         { ^ CancellationTokenRegistration.new() };
+
+      ^ source!.register(action)
+   }
+
+   throwIfCancellationRequested()
+   {
+      if (self.IsCancellationRequested)
+         OperationCanceledException.withToken(self).raise()
+   }
+}
+
+public class OperationCanceledException : Exception
+{
+   CancellationToken _cancellationToken;
+
+   constructor new()
+      <= withToken(CancellationToken.None);
+
+   constructor withToken(CancellationToken cancellationToken)
+   {
+      if (cancellationToken == nil)
+         InvalidArgumentException.raise("cancellationToken");
+
+      initialize("The operation was canceled");
+      _cancellationToken := cancellationToken
+   }
+
+   CancellationToken Token
+      = _cancellationToken;
+}
+
+public sealed class CancellationTokenSource
+{
+   bool                                 _cancellationRequested;
+   CancellationToken                    _token;
+   List<CancellationTokenRegistration>? _registrations;
+
+   constructor new()
+   {
+      _cancellationRequested := false;
+      _token := CancellationToken.new(self)
+   }
+
+   CancellationToken Token
+      = _token;
+
+   bool IsCancellationRequested
+   {
+      get()
+      {
+         bool requested := false;
+         lock(self) {
+            requested := _cancellationRequested
+         };
+
+         ^ requested
+      }
+   }
+
+   internal CancellationTokenRegistration register(Func action)
+   {
+      CancellationTokenRegistration? registration := nil;
+      bool invokeNow := false;
+
+      lock(self) {
+         if (_cancellationRequested) {
+            invokeNow := true
+         }
+         else {
+            registration := CancellationTokenRegistration.new(self, action);
+            if (_registrations == nil)
+               _registrations := new List<CancellationTokenRegistration>();
+
+            _registrations!.append(registration!)
+         }
+      };
+
+      if (invokeNow) {
+         action();
+
+         ^ CancellationTokenRegistration.new()
+      };
+
+      ^ registration!
+   }
+
+   internal unregister(CancellationTokenRegistration registration)
+   {
+      lock(self) {
+         if:not:nil(_registrations) {
+            List<CancellationTokenRegistration> registrations := _registrations!;
+            int index := -1;
+            int len := registrations.Length;
+            for (int i := 0; i < len && index < 0; i += 1) {
+               if (registrations[i].equalReference(registration))
+                  index := i
+            };
+
+            if (index >= 0)
+               registrations.remove(index)
+         }
+      }
+   }
+
+   cancel()
+   {
+      List<CancellationTokenRegistration>? registrations := nil;
+      lock(self) {
+         if:not (_cancellationRequested) {
+            _cancellationRequested := true;
+            registrations := _registrations;
+            _registrations := nil;
+         }
+      };
+
+      List<Exception>? exceptions := nil;
+      if:not:nil(registrations) {
+         List<CancellationTokenRegistration> items := registrations!;
+         for (int i := items.Length - 1; i >= 0; i -= 1) {
+            CancellationTokenRegistration item := items[i];
+            Func? action := item.takeAction();
+            if:not:nil(action) {
+               try {
+                  action()
+               }
+               catch (Exception e) {
+                  if (exceptions == nil)
+                     exceptions := new List<Exception>();
+
+                  exceptions!.append(e)
+               }
+            }
+         }
+      };
+
+      if:not:nil(exceptions)
+         AggregateException.new(exceptions!.Value).raise()
+   }
+}
+
+public class TaskCanceledException : OperationCanceledException
+{
+   constructor new()
+      <= super new();
+
+   constructor withToken(CancellationToken cancellationToken)
+      <= super withToken(cancellationToken);
+}

--- a/src60/system/threading/tasks.l
+++ b/src60/system/threading/tasks.l
@@ -7,6 +7,7 @@ public class Task
    Action<Task>?       _continuation;
    List<Action<Task>>? _continuations;
    Func                _action;
+   CancellationToken?  _cancellationToken;
 
    protected constructor()
    {
@@ -36,6 +37,12 @@ public class Task
          InvalidArgumentException.raise("action");
 
       _action := new StartHelper(action, arg);
+   }
+
+   internal constructor assignCancelable(Func action, CancellationToken cancellationToken)
+      <= assign(action)
+   {
+      _cancellationToken := cancellationToken
    }
 
    private bool isCompletedUnsafe()
@@ -89,6 +96,9 @@ public class Task
       = nil;
 
    indexed internal Exception? Exception = _exception;
+
+   indexed internal CancellationToken cancellationToken
+      = _cancellationToken ?? CancellationToken.None;
 
    private registerContinuation(Action<Task> action)
    {
@@ -145,7 +155,7 @@ public class Task
       ^ continuationTask
    }
 
-   private bool complete(TaskStatus finalStatus, Exception? ex)
+   private bool complete(TaskStatus finalStatus, Exception? ex, CancellationToken? cancellationToken)
    {
       Action<Task>? continuation := nil;
       List<Action<Task>>? continuations := nil;
@@ -155,6 +165,7 @@ public class Task
             { ^ false };
 
          _exception := ex;
+         _cancellationToken := cancellationToken;
          _status := finalStatus;
          continuation := _continuation;
          continuations := _continuations;
@@ -178,19 +189,19 @@ public class Task
 
    internal sealed setResult()
    {
-      if:not (complete(TaskStatus.RanToCompletion, nil))
+      if:not (complete(TaskStatus.RanToCompletion, nil, nil))
          InvalidOperationException.raise("The task is already completed")
    }
 
    internal sealed bool trySetResult()
-      = complete(TaskStatus.RanToCompletion, nil);
+      = complete(TaskStatus.RanToCompletion, nil, nil);
 
    internal sealed setException(Exception ex)
    {
       if (ex == nil)
          InvalidArgumentException.raise("ex");
 
-      if:not (complete(TaskStatus.Faulted, ex))
+      if:not (complete(TaskStatus.Faulted, ex, nil))
          InvalidOperationException.raise("The task is already completed")
    }
 
@@ -199,7 +210,24 @@ public class Task
       if (ex == nil)
          InvalidArgumentException.raise("ex");
 
-      ^ complete(TaskStatus.Faulted, ex)
+      ^ complete(TaskStatus.Faulted, ex, nil)
+   }
+
+   internal sealed setCanceled(CancellationToken cancellationToken)
+   {
+      if (cancellationToken == nil)
+         InvalidArgumentException.raise("cancellationToken");
+
+      if:not (complete(TaskStatus.Canceled, nil, cancellationToken))
+         InvalidOperationException.raise("The task is already completed")
+   }
+
+   internal sealed bool trySetCanceled(CancellationToken cancellationToken)
+   {
+      if (cancellationToken == nil)
+         InvalidArgumentException.raise("cancellationToken");
+
+      ^ complete(TaskStatus.Canceled, nil, cancellationToken)
    }
 
    sealed wait()
@@ -215,11 +243,49 @@ public class Task
          }
       };
 
+      if (self.IsCanceled)
+         TaskCanceledException.withToken(self.cancellationToken).raise();
+
       Exception? exception := self.Exception;
       if:not:nil(exception)
          exception.raise();
 
       ^ self
+   }
+
+   private executeAction()
+   {
+      CancellationToken cancellationToken := _cancellationToken ?? CancellationToken.None;
+      bool hasCancellationToken := _cancellationToken != nil;
+
+      if (hasCancellationToken && cancellationToken.IsCancellationRequested) {
+         trySetCanceled(cancellationToken)
+      }
+      else {
+         try
+         {
+            _action();
+            setResult()
+         }
+         catch::
+         {
+            function(OperationCanceledException e)
+            {
+               if (hasCancellationToken
+                  && cancellationToken.IsCancellationRequested
+                  && cancellationToken.equalReference(e.Token))
+               {
+                  trySetCanceled(e.Token)
+               }
+               else trySetException(e)
+            }
+
+            function(Exception e)
+            {
+               trySetException(e)
+            }
+         }
+      }
    }
 
    sealed start()
@@ -237,13 +303,7 @@ public class Task
             _status := TaskStatus.Running
          };
 
-         try {
-            _action();
-            setResult();
-         }
-         catch (Exception e) {
-            trySetException(e);
-         }
+         executeAction()
       });
    }
 
@@ -255,9 +315,16 @@ public class Task
       if (tasks == nil)
          InvalidArgumentException.raise("tasks");
 
+      int length := tasks.Length;
+      int remaining := length;
+      for (int i := 0; i < length; i += 1) {
+         if (tasks[i] == nil)
+            InvalidArgumentException.raise("tasks")
+      };
+
       Task promise := Task.newPromise();
-      int remaining := tasks.Length;
-      List<Exception> exceptions := new List<Exception>();
+      List<Exception>? exceptions := nil;
+      CancellationToken? cancellationToken := nil;
 
       if (remaining == 0) {
          promise.setResult();
@@ -269,17 +336,30 @@ public class Task
       {
          bool last := false;
          lock(promise) {
-            Exception? exception := completed.Exception;
-            if:not:nil(exception)
-               exceptions.append(exception);
+            if (completed.IsCanceled) {
+               if (cancellationToken == nil)
+                  cancellationToken := completed.cancellationToken
+            }
+            else {
+               Exception? exception := completed.Exception;
+               if:not:nil(exception) {
+                  if (exceptions == nil)
+                     exceptions := new List<Exception>();
+
+                  exceptions!.append(exception)
+               }
+            };
 
             remaining := remaining - 1;
             last := remaining == 0;
          };
 
          if (last) {
-            if (exceptions.Length > 0) {
-               promise.setException(AggregateException.new(exceptions.Value))
+            if (exceptions != nil) {
+               promise.setException(AggregateException.new(exceptions!.Value))
+            }
+            else if (cancellationToken != nil) {
+               promise.setCanceled(cancellationToken!)
             }
             else {
                promise.setResult()
@@ -287,14 +367,8 @@ public class Task
          }
       };
 
-      int len := tasks.Length;
-      for (int i := 0; i < len; i += 1) {
-         Task task := tasks[i];
-         if (task == nil)
-            InvalidArgumentException.raise("tasks");
-
-         task.onCompleted(continuation);
-      };
+      for (int i := 0; i < length; i += 1)
+         tasks[i].onCompleted(continuation);
 
       ^ promise
    }
@@ -321,12 +395,58 @@ public class Task
       ^ task
    }
 
+   static Task run(Func action, CancellationToken token)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      if (token == nil)
+         InvalidArgumentException.raise("token");
+
+      if:not (token.CanBeCanceled)
+         { ^ Task.run(action) };
+
+      if (token.IsCancellationRequested)
+         { ^ Task.fromCanceled(token) };
+
+      Task task := Task.assignCancelable(action, token);
+      task.start();
+
+      ^ task
+   }
+
    static Task sleep(int msecs)
    {
       if (msecs < 0)
          InvalidArgumentException.raise("msecs");
 
       ^ Task.run({ Thread.sleep(msecs) })
+   }
+
+   static Task sleep(int msecs, CancellationToken token)
+   {
+      if (msecs < 0)
+         InvalidArgumentException.raise("msecs");
+
+      if (token == nil)
+         InvalidArgumentException.raise("token");
+
+      if:not (token.CanBeCanceled)
+         { ^ Task.sleep(msecs) };
+
+      ^ Task.run(
+         {
+            int remaining := msecs;
+            while (remaining > 0) {
+               token.throwIfCancellationRequested();
+
+               int interval := (remaining > 10) ? 10 : remaining;
+               Thread.sleep(interval);
+               remaining := remaining - interval;
+            };
+
+            token.throwIfCancellationRequested()
+         }, token)
    }
 
    static Task completedTask()
@@ -341,6 +461,20 @@ public class Task
    {
       Task task := Task.newPromise();
       task.setException(ex);
+
+      ^ task
+   }
+
+   static Task fromCanceled(CancellationToken cancellationToken)
+   {
+      if (cancellationToken == nil)
+         InvalidArgumentException.raise("cancellationToken");
+
+      if:not (cancellationToken.IsCancellationRequested)
+         InvalidArgumentException.raise("cancellationToken");
+
+      Task task := Task.newPromise();
+      task.setCanceled(cancellationToken);
 
       ^ task
    }
@@ -383,6 +517,12 @@ public sealed class Task<TResult> : Task
       };
    }
 
+   internal constructor assignCancelable(Func<TResult> func, CancellationToken cancellationToken)
+      <= assign(func)
+   {
+      _cancellationToken := cancellationToken
+   }
+
    indexed internal setResultValue(TResult result)
    {
       lock(self) {
@@ -411,6 +551,40 @@ public sealed class Task<TResult> : Task
       ^ task
    }
 
+   static Task<TResult> run(Func<TResult> action, CancellationToken token)
+   {
+      if (action == nil)
+         InvalidArgumentException.raise("action");
+
+      if (token == nil)
+         InvalidArgumentException.raise("token");
+
+      if:not (token.CanBeCanceled)
+         { ^ class Task<TResult>.run(action) };
+
+      if (token.IsCancellationRequested)
+         { ^ class Task<TResult>.fromCanceled(token) };
+
+      Task<TResult> task := class Task<TResult>.assignCancelable(action, token);
+      task.start();
+
+      ^ task
+   }
+
    static Task<TResult> fromResult(TResult result)
       = new Task<TResult>(result);
+
+   static Task<TResult> fromCanceled(CancellationToken cancellationToken)
+   {
+      if (cancellationToken == nil)
+         InvalidArgumentException.raise("cancellationToken");
+
+      if:not (cancellationToken.IsCancellationRequested)
+         InvalidArgumentException.raise("cancellationToken");
+
+      Task<TResult> task := class Task<TResult>.newPromise();
+      task.setCanceled(cancellationToken);
+
+      ^ task
+   }
 }

--- a/src60/system/threading/templates.l
+++ b/src60/system/threading/templates.l
@@ -23,18 +23,26 @@ public abstract class AsyncStateEnumerator : Enumerator<Task>
       {
          try
          {
-             if (e.next()) {
-                (*e).continueWith(this self);
+            if (e.next()) {
+               (*e).onCompleted(this self);
 
-                ^ this self;
-             };
+               ^ this self;
+            };
 
-             t.setResult(); 
+            t.setResult()
          }
-         catch (Exception e)
+         catch::
          {
-            t.setException(e);
-         };
+            function(OperationCanceledException e)
+            {
+               t.setCanceled(e.Token)
+            }
+
+            function(Exception e)
+            {
+               t.setException(e)
+            }
+         }
       };
 
       proceeding(t);
@@ -68,19 +76,27 @@ public abstract class AsyncStateEnumerator<TResult> : Enumerator<Task>
       {
          try
          {
-             if (e.next()) {
-                (*e).continueWith(this self);
+            if (e.next()) {
+               (*e).onCompleted(this self);
 
-                ^ this self;
-             }
-             else t.setResultValue((*e).getResultUnsafe());
+               ^ this self;
+            }
+            else t.setResultValue((*e).getResultUnsafe());
 
-             t.setResult(); 
+            t.setResult()
          }
-         catch (Exception e)
+         catch::
          {
-            t.setException(e);
-         };
+            function(OperationCanceledException e)
+            {
+               t.setCanceled(e.Token)
+            }
+
+            function(Exception e)
+            {
+               t.setException(e)
+            }
+         }
       };
 
       proceeding(t);

--- a/tests60/async_tests/async_tests.prj
+++ b/tests60/async_tests/async_tests.prj
@@ -18,6 +18,7 @@
      <module>
         <include>main.l</include>
         <include>basic.l</include>
+        <include>cancellation.l</include>
      </module>
   </files>
 </configuration>

--- a/tests60/async_tests/cancellation.l
+++ b/tests60/async_tests/cancellation.l
@@ -1,0 +1,653 @@
+import extensions;
+import system'threading;
+import ltests;
+
+class CancellationTestException : Exception
+{
+   constructor new(string message)
+      <= super new(message);
+}
+
+singleton CancellationTestCounter
+{
+   static object _sync := new object();
+   static int _value := 0;
+
+   reset()
+   {
+      lock(_sync) {
+         _value := 0
+      }
+   }
+
+   increment()
+   {
+      lock(_sync) {
+         _value := _value + 1
+      }
+   }
+
+   int Value
+   {
+      get()
+      {
+         int value := 0;
+         lock(_sync) {
+            value := _value
+         };
+
+         ^ value
+      }
+   }
+}
+
+incrementCancellationTestCounter()
+{
+   CancellationTestCounter.increment()
+}
+
+recordCanceledContinuation(Task completed)
+{
+   Assert.ifTrue(completed.IsCanceled);
+   CancellationTestCounter.increment()
+}
+
+bool waitForTaskCompletion(Task task, int timeout)
+{
+   ManualResetEvent completed := ManualResetEvent.new();
+   task.continueWith((Task antecedent){ completed.set() });
+
+   bool signaled := completed.wait(timeout);
+   if (signaled)
+      completed.close();
+
+   ^ signaled
+}
+
+class AsyncCancellationScenarios
+{
+   private Task cancellableOperation(CancellationToken token, ManualResetEvent entered)
+   {
+      ^ Task.run(
+         {
+            entered.set();
+            while (token.IsCancellationRequested.Inverted)
+               Thread.sleep(1);
+
+            token.throwIfCancellationRequested()
+         }, token)
+   }
+
+   async Task waitAsync(CancellationToken token, ManualResetEvent entered)
+   {
+      :await cancellableOperation(token, entered);
+
+      CancellationTestCounter.increment()
+   }
+
+   async Task<int> valueAsync(CancellationToken token, ManualResetEvent entered)
+   {
+      :await cancellableOperation(token, entered);
+
+      CancellationTestCounter.increment();
+
+      ^ 42
+   }
+
+   async Task<int> transformAsync(CancellationToken token, ManualResetEvent entered)
+   {
+      int value := :await valueAsync(token, entered);
+
+      CancellationTestCounter.increment();
+
+      ^ value + 1
+   }
+
+   async Task<int> nestedAsync(CancellationToken token, ManualResetEvent entered)
+   {
+      int value := :await transformAsync(token, entered);
+
+      CancellationTestCounter.increment();
+
+      ^ value + 1
+   }
+
+   async Task<int> recoverAsync(CancellationToken token, ManualResetEvent entered)
+   {
+      int result := 42;
+      try {
+         :await cancellableOperation(token, entered)
+      }
+      catch (TaskCanceledException e) {
+         result := -1
+      };
+
+      ^ result
+   }
+
+   async Task withFinallyAsync(CancellationToken token, ManualResetEvent entered)
+   {
+      try {
+         :await cancellableOperation(token, entered)
+      }
+      finally {
+         CancellationTestCounter.increment()
+      }
+   }
+
+   async Task<int> completeWithoutObservationAsync(Task gate, CancellationToken token)
+   {
+      :await gate;
+
+      ^ 7
+   }
+
+   async Task<int> observeAfterResumeAsync(Task gate, CancellationToken token)
+   {
+      :await gate;
+      token.throwIfCancellationRequested();
+
+      ^ 7
+   }
+
+   async Task faultAfterResumeAsync(Task gate, CancellationToken token)
+   {
+      :await gate;
+
+      CancellationTestException.raise("fault after cancellation")
+   }
+}
+
+public canceledTaskTest() : testCase()
+{
+   CancellationTokenSource source := CancellationTokenSource.new();
+   source.cancel();
+
+   CancellationTestCounter.reset();
+   Task canceledTask := Task.run(&incrementCancellationTestCounter, source.Token);
+   Assert.ifEqual(CancellationTestCounter.Value, 0);
+   Assert.ifTrue(canceledTask.IsCompleted);
+   Assert.ifTrue(canceledTask.IsCanceled);
+   Assert.ifFalse(canceledTask.IsFaulted);
+   Assert.ifFalse(canceledTask.IsCompletedSuccessfully);
+
+   bool canceledRaised := false;
+   try {
+      canceledTask.wait()
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+
+   Task<int> canceledRun := class Task<int>.run(
+      {
+         CancellationTestCounter.increment();
+
+         ^ 42
+      }, source.Token);
+   Assert.ifTrue(canceledRun.IsCanceled);
+   Assert.ifEqual(CancellationTestCounter.Value, 0);
+
+   Task<int> canceledValue := class Task<int>.fromCanceled(source.Token);
+   canceledRaised := false;
+   try {
+      int value := canceledValue.Result
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+
+   bool invalidTokenRaised := false;
+   try {
+      Task.fromCanceled(CancellationTokenSource.new().Token)
+   }
+   catch (InvalidArgumentException e) {
+      invalidTokenRaised := true
+   };
+   Assert.ifTrue(invalidTokenRaised);
+
+   Console.write(".")
+}
+
+public taskCancellationTokenAssociationTest() : testCase()
+{
+   CancellationTokenSource source := CancellationTokenSource.new();
+   ManualResetEvent entered := ManualResetEvent.new();
+   ManualResetEvent release := ManualResetEvent.new();
+   Task canceled := Task.run(
+      {
+         entered.set();
+         release.wait();
+         source.Token.throwIfCancellationRequested()
+      }, source.Token);
+
+   Assert.ifTrue(entered.wait(5000));
+   source.cancel();
+   release.set();
+   Assert.ifTrue(waitForTaskCompletion(canceled, 5000));
+
+   bool canceledRaised := false;
+   try {
+      canceled.wait()
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(canceled.IsCanceled);
+   entered.close();
+   release.close();
+
+   CancellationTokenSource taskSource := CancellationTokenSource.new();
+   CancellationTokenSource otherSource := CancellationTokenSource.new();
+   entered := ManualResetEvent.new();
+   release := ManualResetEvent.new();
+   Task mismatched := Task.run(
+      {
+         entered.set();
+         release.wait();
+         otherSource.Token.throwIfCancellationRequested()
+      }, taskSource.Token);
+
+   Assert.ifTrue(entered.wait(5000));
+   taskSource.cancel();
+   otherSource.cancel();
+   release.set();
+   Assert.ifTrue(waitForTaskCompletion(mismatched, 5000));
+
+   bool faultRaised := false;
+   try {
+      mismatched.wait()
+   }
+   catch (OperationCanceledException e) {
+      faultRaised := true;
+      Assert.ifTrue(e.Token.equalReference(otherSource.Token))
+   };
+   Assert.ifTrue(faultRaised);
+   Assert.ifTrue(mismatched.IsFaulted);
+   Assert.ifFalse(mismatched.IsCanceled);
+   entered.close();
+   release.close();
+
+   source := CancellationTokenSource.new();
+   entered := ManualResetEvent.new();
+   release := ManualResetEvent.new();
+   Task completed := Task.run(
+      {
+         entered.set();
+         release.wait()
+      }, source.Token);
+
+   Assert.ifTrue(entered.wait(5000));
+   source.cancel();
+   release.set();
+   completed.wait();
+   Assert.ifTrue(completed.IsCompletedSuccessfully);
+   entered.close();
+   release.close();
+
+   Console.write(".")
+}
+
+public taskCancellationExceptionClassificationTest() : testCase()
+{
+   Task unrelatedCancellation := Task.run({ OperationCanceledException.raise() });
+   bool faultRaised := false;
+   try {
+      unrelatedCancellation.wait()
+   }
+   catch (OperationCanceledException e) {
+      faultRaised := true;
+      Assert.ifTrue(e.Token.equalReference(CancellationToken.None))
+   };
+   Assert.ifTrue(faultRaised);
+   Assert.ifTrue(unrelatedCancellation.IsFaulted);
+   Assert.ifFalse(unrelatedCancellation.IsCanceled);
+
+   CancellationTokenSource source := CancellationTokenSource.new();
+   Task cancellationNotRequested := Task.run(
+      { OperationCanceledException.withToken(source.Token).raise() }, source.Token);
+
+   faultRaised := false;
+   try {
+      cancellationNotRequested.wait()
+   }
+   catch (OperationCanceledException e) {
+      faultRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(faultRaised);
+   Assert.ifTrue(cancellationNotRequested.IsFaulted);
+   Assert.ifFalse(cancellationNotRequested.IsCanceled);
+
+   source := CancellationTokenSource.new();
+   ManualResetEvent entered := ManualResetEvent.new();
+   ManualResetEvent release := ManualResetEvent.new();
+   Task regularFailure := Task.run(
+      {
+         entered.set();
+         release.wait();
+         CancellationTestException.raise("failure after cancellation")
+      }, source.Token);
+
+   Assert.ifTrue(entered.wait(5000));
+   source.cancel();
+   release.set();
+   Assert.ifTrue(waitForTaskCompletion(regularFailure, 5000));
+
+   faultRaised := false;
+   try {
+      regularFailure.wait()
+   }
+   catch (CancellationTestException e) {
+      faultRaised := true
+   };
+   Assert.ifTrue(faultRaised);
+   Assert.ifTrue(regularFailure.IsFaulted);
+   Assert.ifFalse(regularFailure.IsCanceled);
+   entered.close();
+   release.close();
+
+   Console.write(".")
+}
+
+public cooperativeTaskCancellationTest() : testCase()
+{
+   CancellationTokenSource source := CancellationTokenSource.new();
+   Task delayed := Task.sleep(1000, source.Token);
+   Assert.ifFalse(delayed.IsCompleted);
+   source.cancel();
+   Assert.ifTrue(waitForTaskCompletion(delayed, 5000));
+
+   bool canceledRaised := false;
+   try {
+      delayed.wait()
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(delayed.IsCanceled);
+
+   Task continuation := Task.completedTask().continueWith(
+      (Task completed)
+      {
+         OperationCanceledException.raise()
+      });
+
+   bool faultRaised := false;
+   try {
+      continuation.wait()
+   }
+   catch (OperationCanceledException e) {
+      faultRaised := true
+   };
+   Assert.ifTrue(faultRaised);
+   Assert.ifTrue(continuation.IsFaulted);
+   Assert.ifFalse(continuation.IsCanceled);
+
+   Console.write(".")
+}
+
+public nonCancelableTokenTaskTest() : testCase()
+{
+   Task completedDelay := Task.sleep(5, CancellationToken.None);
+   completedDelay.wait();
+   Assert.ifTrue(completedDelay.IsCompletedSuccessfully);
+
+   Task completedAction := Task.run({}, CancellationToken.None);
+   completedAction.wait();
+   Assert.ifTrue(completedAction.IsCompletedSuccessfully);
+
+   Task<int> completedValue := class Task<int>.run({ ^ 42 }, CancellationToken.None);
+   Assert.ifEqual(completedValue.Result, 42);
+
+   Console.write(".")
+}
+
+public canceledTaskContinuationsTest() : testCase()
+{
+   int continuationCount := 32;
+   Task[] continuations := new Task[](continuationCount);
+   CancellationTokenSource source := CancellationTokenSource.new();
+   source.cancel();
+
+   CancellationTestCounter.reset();
+   for (int i := 0; i < continuationCount; i += 1)
+      continuations[i] := Task.fromCanceled(source.Token).continueWith(&recordCanceledContinuation);
+
+   Task.whenAll(continuations).wait();
+   Assert.ifEqual(CancellationTestCounter.Value, continuationCount);
+
+   Console.write(".")
+}
+
+public whenAllCancellationTest() : testCase()
+{
+   CancellationTokenSource source := CancellationTokenSource.new();
+   source.cancel();
+
+   Task[] canceledTasks := new Task[](2);
+   canceledTasks[0] := Task.fromCanceled(source.Token);
+   canceledTasks[1] := Task.completedTask();
+
+   Task canceledAll := Task.whenAll(canceledTasks);
+   bool canceledRaised := false;
+   try {
+      canceledAll.wait()
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(canceledAll.IsCanceled);
+
+   Task[] mixedTasks := new Task[](2);
+   mixedTasks[0] := Task.fromCanceled(source.Token);
+   mixedTasks[1] := Task.fromException(CancellationTestException.new("failed"));
+
+   Task mixedAll := Task.whenAll(mixedTasks);
+   bool aggregateRaised := false;
+   try {
+      mixedAll.wait()
+   }
+   catch (AggregateException e) {
+      aggregateRaised := true;
+      Assert.ifEqual(e.InnerExceptions.Length, 1)
+   };
+   Assert.ifTrue(aggregateRaised);
+   Assert.ifTrue(mixedAll.IsFaulted);
+
+   ManualResetEvent gate := ManualResetEvent.new();
+   Task pending := Task.run({ gate.wait() });
+   Task[] pendingTasks := new Task[](2);
+   pendingTasks[0] := Task.fromCanceled(source.Token);
+   pendingTasks[1] := pending;
+
+   Task pendingAll := Task.whenAll(pendingTasks);
+   Assert.ifFalse(pendingAll.IsCompleted);
+   gate.set();
+   Assert.ifTrue(waitForTaskCompletion(pendingAll, 5000));
+
+   canceledRaised := false;
+   try {
+      pendingAll.wait()
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(pendingAll.IsCanceled);
+   gate.close();
+
+   int completedCount := 128;
+   Task[] completedTasks := new Task[](completedCount);
+   for (int i := 0; i < completedCount; i += 1)
+      completedTasks[i] := Task.fromCanceled(source.Token);
+
+   Task completedAll := Task.whenAll(completedTasks);
+   Assert.ifTrue(waitForTaskCompletion(completedAll, 5000));
+   Assert.ifTrue(completedAll.IsCanceled);
+
+   Console.write(".")
+}
+
+public asyncCancellationPropagationTest() : testCase()
+{
+   AsyncCancellationScenarios scenarios := new AsyncCancellationScenarios();
+
+   CancellationTestCounter.reset();
+   CancellationTokenSource source := CancellationTokenSource.new();
+   ManualResetEvent entered := ManualResetEvent.new();
+   Task task := scenarios.waitAsync(source.Token, entered);
+   Assert.ifTrue(entered.wait(5000));
+   Assert.ifFalse(task.IsCompleted);
+   source.cancel();
+   Assert.ifTrue(waitForTaskCompletion(task, 5000));
+
+   bool canceledRaised := false;
+   try {
+      task.wait()
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(task.IsCanceled);
+   Assert.ifEqual(CancellationTestCounter.Value, 0);
+   entered.close();
+
+   source := CancellationTokenSource.new();
+   entered := ManualResetEvent.new();
+   Task<int> valueTask := scenarios.nestedAsync(source.Token, entered);
+   Assert.ifTrue(entered.wait(5000));
+   Assert.ifFalse(valueTask.IsCompleted);
+   source.cancel();
+   Assert.ifTrue(waitForTaskCompletion(valueTask, 5000));
+
+   canceledRaised := false;
+   try {
+      int value := valueTask.Result
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(valueTask.IsCanceled);
+   Assert.ifEqual(CancellationTestCounter.Value, 0);
+   entered.close();
+
+   Console.write(".")
+}
+
+public asyncCancellationControlFlowTest() : testCase()
+{
+   AsyncCancellationScenarios scenarios := new AsyncCancellationScenarios();
+
+   CancellationTokenSource source := CancellationTokenSource.new();
+   ManualResetEvent entered := ManualResetEvent.new();
+   Task<int> recovered := scenarios.recoverAsync(source.Token, entered);
+   Assert.ifTrue(entered.wait(5000));
+   Assert.ifFalse(recovered.IsCompleted);
+   source.cancel();
+   Assert.ifTrue(waitForTaskCompletion(recovered, 5000));
+   Assert.ifEqual(recovered.Result, -1);
+   Assert.ifTrue(recovered.IsCompletedSuccessfully);
+   entered.close();
+
+   CancellationTestCounter.reset();
+   source := CancellationTokenSource.new();
+   entered := ManualResetEvent.new();
+   Task finalizing := scenarios.withFinallyAsync(source.Token, entered);
+   Assert.ifTrue(entered.wait(5000));
+   Assert.ifFalse(finalizing.IsCompleted);
+   source.cancel();
+   Assert.ifTrue(waitForTaskCompletion(finalizing, 5000));
+
+   bool canceledRaised := false;
+   try {
+      finalizing.wait()
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(finalizing.IsCanceled);
+   Assert.ifEqual(CancellationTestCounter.Value, 1);
+   entered.close();
+
+   Console.write(".")
+}
+
+public asyncCancellationObservationTest() : testCase()
+{
+   AsyncCancellationScenarios scenarios := new AsyncCancellationScenarios();
+
+   CancellationTokenSource source := CancellationTokenSource.new();
+   ManualResetEvent gate := ManualResetEvent.new();
+   Task blocker := Task.run({ gate.wait() });
+   Task<int> unobserved := scenarios.completeWithoutObservationAsync(blocker, source.Token);
+   Assert.ifFalse(unobserved.IsCompleted);
+   source.cancel();
+   gate.set();
+   Assert.ifTrue(waitForTaskCompletion(unobserved, 5000));
+   Assert.ifEqual(unobserved.Result, 7);
+   Assert.ifTrue(unobserved.IsCompletedSuccessfully);
+   gate.close();
+
+   source := CancellationTokenSource.new();
+   gate := ManualResetEvent.new();
+   blocker := Task.run({ gate.wait() });
+   Task<int> observed := scenarios.observeAfterResumeAsync(blocker, source.Token);
+   Assert.ifFalse(observed.IsCompleted);
+   source.cancel();
+   gate.set();
+   Assert.ifTrue(waitForTaskCompletion(observed, 5000));
+
+   bool canceledRaised := false;
+   try {
+      int value := observed.Result
+   }
+   catch (TaskCanceledException e) {
+      canceledRaised := true;
+      Assert.ifTrue(e.Token.equalReference(source.Token))
+   };
+   Assert.ifTrue(canceledRaised);
+   Assert.ifTrue(observed.IsCanceled);
+   gate.close();
+
+   source := CancellationTokenSource.new();
+   gate := ManualResetEvent.new();
+   blocker := Task.run({ gate.wait() });
+   Task faulted := scenarios.faultAfterResumeAsync(blocker, source.Token);
+   Assert.ifFalse(faulted.IsCompleted);
+   source.cancel();
+   gate.set();
+   Assert.ifTrue(waitForTaskCompletion(faulted, 5000));
+
+   bool faultRaised := false;
+   try {
+      faulted.wait()
+   }
+   catch (CancellationTestException e) {
+      faultRaised := true
+   };
+   Assert.ifTrue(faultRaised);
+   Assert.ifTrue(faulted.IsFaulted);
+   Assert.ifFalse(faulted.IsCanceled);
+   gate.close();
+
+   Console.write(".")
+}

--- a/tests60/mta_tests/cancellation_tests.l
+++ b/tests60/mta_tests/cancellation_tests.l
@@ -1,0 +1,545 @@
+import extensions;
+import system'threading;
+import ltests;
+
+class CancellationCallbackException : Exception
+{
+   constructor new(string message)
+      <= super new(message);
+}
+
+class CallbackOrder
+{
+   int  _next;
+   bool _valid;
+
+   constructor new(int count)
+   {
+      _next := count;
+      _valid := true
+   }
+
+   record(int position)
+   {
+      lock(self)
+      {
+         if (_next != position)
+            _valid := false;
+
+         _next := _next - 1
+      }
+   }
+
+   bool IsValid
+   {
+      get()
+      {
+         bool valid := false;
+         lock(self)
+         {
+            valid := _valid && _next == 0
+         };
+
+         ^ valid
+      }
+   }
+}
+
+class RegistrationHolder
+{
+   CancellationTokenRegistration Registration : prop;
+   SharedCounter Counter : prop;
+
+   invoke()
+   {
+      Registration.close();
+      Counter.increment()
+   }
+}
+
+public cancellationTokenTest() : testCase()
+{
+   CancellationToken none := CancellationToken.None;
+   Assert.ifFalse(none.CanBeCanceled);
+   Assert.ifFalse(none.IsCancellationRequested);
+
+   OperationCanceledException defaultCancellation := OperationCanceledException.new();
+   Assert.ifTrue(defaultCancellation.Token.equalReference(none));
+
+   CancellationTokenSource source := CancellationTokenSource.new();
+   CancellationToken token := source.Token;
+   Assert.ifTrue(token.CanBeCanceled);
+   Assert.ifFalse(token.IsCancellationRequested);
+
+   source.cancel();
+   source.cancel();
+   Assert.ifTrue(source.IsCancellationRequested);
+   Assert.ifTrue(token.IsCancellationRequested);
+
+   bool canceled := false;
+   try
+   {
+      token.throwIfCancellationRequested()
+   }
+   catch(OperationCanceledException e)
+   {
+      canceled := true;
+      Assert.ifTrue(e.Token.equalReference(token))
+   };
+
+   Assert.ifTrue(canceled);
+
+   Console.write(".")
+}
+
+public cancellationRegistrationTest() : testCase()
+{
+   CancellationTokenSource source := CancellationTokenSource.new();
+   SharedCounter counter := SharedCounter.new();
+   CallbackOrder order := CallbackOrder.new(3);
+
+   source.Token.register({ order.record(1); counter.increment() });
+   source.Token.register({ order.record(2); CancellationCallbackException.raise("first callback") });
+   source.Token.register({ order.record(3); CancellationCallbackException.raise("second callback") });
+
+   bool aggregateRaised := false;
+   try
+   {
+      source.cancel()
+   }
+   catch(AggregateException e)
+   {
+      aggregateRaised := true;
+      Assert.ifEqual(e.InnerExceptions.Length, 2)
+   };
+
+   Assert.ifTrue(aggregateRaised);
+   Assert.ifTrue(order.IsValid);
+   Assert.ifEqual(counter.Value, 1);
+
+   source.cancel();
+   Assert.ifEqual(counter.Value, 1);
+
+   bool lateRaised := false;
+   try
+   {
+      source.Token.register({ CancellationCallbackException.raise("late callback") })
+   }
+   catch(CancellationCallbackException e)
+   {
+      lateRaised := true
+   };
+   Assert.ifTrue(lateRaised);
+
+   CancellationTokenRegistration late := source.Token.register({ counter.increment() });
+   Assert.ifEqual(counter.Value, 2);
+   late.close();
+
+   source := CancellationTokenSource.new();
+   CancellationTokenRegistration removed := source.Token.register({ counter.increment() });
+   removed.close();
+   removed.close();
+   source.cancel();
+   Assert.ifEqual(counter.Value, 2);
+
+   source := CancellationTokenSource.new();
+   bool scopeRaised := false;
+   try
+   {
+      using(CancellationTokenRegistration registration := source.Token.register({ counter.increment() }))
+      {
+         CancellationCallbackException.raise("registration scope")
+      }
+   }
+   catch(CancellationCallbackException e)
+   {
+      scopeRaised := true
+   };
+
+   Assert.ifTrue(scopeRaised);
+   source.cancel();
+   Assert.ifEqual(counter.Value, 2);
+
+   Console.write(".")
+}
+
+public cancellationRegistrationReentrancyTest() : testCase()
+{
+   CancellationTokenSource source := CancellationTokenSource.new();
+   SharedCounter counter := SharedCounter.new();
+   CancellationTokenRegistration first := source.Token.register({ counter.increment() });
+
+   source.Token.register(
+      {
+         first.close();
+         source.cancel()
+      });
+
+   source.cancel();
+   Assert.ifEqual(counter.Value, 0);
+
+   source := CancellationTokenSource.new();
+   RegistrationHolder holder := new RegistrationHolder();
+   holder.Counter := counter;
+   holder.Registration := source.Token.register({ holder.invoke() });
+   source.cancel();
+   Assert.ifEqual(counter.Value, 1);
+
+   Console.write(".")
+}
+
+class RegisterRaceState
+{
+   Array Sources : prop;
+   Array Counters : prop;
+   Array Completed : prop;
+   RoundBarrier Barrier : prop;
+   int Rounds : prop;
+   ErrorBox Errors : prop;
+}
+
+registerRaceWorker(state)
+{
+   auto sources := state.Sources;
+   auto counters := state.Counters;
+   auto completedItems := state.Completed;
+
+   for (int round := 0; round < state.Rounds; round += 1)
+   {
+      auto source := sources[round];
+      auto counter := counters[round];
+      auto completed := completedItems[round];
+
+      try
+      {
+         state.Barrier.arrive(round);
+         source.Token.register({ counter.increment() })
+      }
+      catch(Exception e)
+      {
+         state.Errors.record(e)
+      };
+
+      completed.done()
+   }
+}
+
+public cancellationRegisterRaceTest() : testCase()
+{
+   int workers := MtaLoad.WorkerCount;
+   int rounds := MtaLoad.Repetitions;
+   auto sources := Array.allocate(rounds);
+   auto counters := Array.allocate(rounds);
+   auto completed := Array.allocate(rounds);
+
+   for (int round := 0; round < rounds; round += 1)
+   {
+      sources[round] := CancellationTokenSource.new();
+      counters[round] := SharedCounter.new();
+      completed[round] := Latch.new(workers)
+   };
+
+   RegisterRaceState state := new RegisterRaceState();
+   state.Sources := sources;
+   state.Counters := counters;
+   state.Completed := completed;
+   state.Barrier := RoundBarrier.new(workers, rounds);
+   state.Rounds := rounds;
+   state.Errors := ErrorBox.new();
+
+   for (int i := 0; i < workers; i += 1)
+   {
+      Thread worker := Thread.assign(&registerRaceWorker);
+      worker.start(state)
+   };
+
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto source := sources[round];
+      auto counter := counters[round];
+      auto done := completed[round];
+
+      state.Barrier.releaseAll(round);
+      source.cancel();
+      done.await();
+
+      Assert.ifEqual(counter.Value, workers)
+   };
+
+   state.Errors.rethrowIfAny();
+   state.Barrier.close();
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto done := completed[round];
+      done.close()
+   };
+
+   Console.write(".")
+}
+
+class CancelRaceState
+{
+   Array Sources : prop;
+   Array Completed : prop;
+   RoundBarrier Barrier : prop;
+   int Rounds : prop;
+   ErrorBox Errors : prop;
+}
+
+cancelRaceWorker(state)
+{
+   auto sources := state.Sources;
+   auto completedItems := state.Completed;
+
+   for (int round := 0; round < state.Rounds; round += 1)
+   {
+      auto source := sources[round];
+      auto completed := completedItems[round];
+
+      try
+      {
+         state.Barrier.arrive(round);
+         source.cancel()
+      }
+      catch(Exception e)
+      {
+         state.Errors.record(e)
+      };
+
+      completed.done()
+   }
+}
+
+public cancellationConcurrentCancelTest() : testCase()
+{
+   int workers := MtaLoad.WorkerCount;
+   int rounds := MtaLoad.Repetitions;
+   auto sources := Array.allocate(rounds);
+   auto counters := Array.allocate(rounds);
+   auto completed := Array.allocate(rounds);
+
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto source := CancellationTokenSource.new();
+      auto counter := SharedCounter.new();
+      for (int i := 0; i < workers; i += 1)
+         source.Token.register({ counter.increment() });
+
+      sources[round] := source;
+      counters[round] := counter;
+      completed[round] := Latch.new(workers)
+   };
+
+   CancelRaceState state := new CancelRaceState();
+   state.Sources := sources;
+   state.Completed := completed;
+   state.Barrier := RoundBarrier.new(workers, rounds);
+   state.Rounds := rounds;
+   state.Errors := ErrorBox.new();
+
+   for (int i := 0; i < workers; i += 1)
+   {
+      Thread worker := Thread.assign(&cancelRaceWorker);
+      worker.start(state)
+   };
+
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto done := completed[round];
+      auto counter := counters[round];
+
+      state.Barrier.releaseAll(round);
+      done.await();
+
+      Assert.ifEqual(counter.Value, workers)
+   };
+
+   state.Errors.rethrowIfAny();
+   state.Barrier.close();
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto done := completed[round];
+      done.close()
+   };
+
+   Console.write(".")
+}
+
+class OnceCallback : interface<Func>
+{
+   int  _calls;
+   bool _duplicated;
+
+   constructor new()
+   {
+      _calls := 0;
+      _duplicated := false
+   }
+
+   invoke()
+   {
+      lock(self)
+      {
+         _calls := _calls + 1;
+         if (_calls > 1)
+            _duplicated := true
+      }
+   }
+
+   function()
+   {
+      invoke()
+   }
+
+   int Calls
+   {
+      get()
+      {
+         int calls := 0;
+         lock(self)
+         {
+            calls := _calls
+         };
+
+         ^ calls
+      }
+   }
+
+   bool Duplicated
+   {
+      get()
+      {
+         bool duplicated := false;
+         lock(self)
+         {
+            duplicated := _duplicated
+         };
+
+         ^ duplicated
+      }
+   }
+}
+
+class CloseRaceState
+{
+   Array Registrations : prop;
+   Array Completed : prop;
+   RoundBarrier Barrier : prop;
+   int Rounds : prop;
+   ErrorBox Errors : prop;
+}
+
+class CloseRaceWorkerArg
+{
+   int Index : prop;
+   CloseRaceState State : prop;
+}
+
+closeRaceWorker(arg)
+{
+   int index := arg.Index;
+   auto state := arg.State;
+   auto registrationRows := state.Registrations;
+   auto completedItems := state.Completed;
+
+   for (int round := 0; round < state.Rounds; round += 1)
+   {
+      auto registrations := registrationRows[round];
+      auto registration := registrations[index];
+      auto completed := completedItems[round];
+
+      try
+      {
+         state.Barrier.arrive(round);
+         registration.close()
+      }
+      catch(Exception e)
+      {
+         state.Errors.record(e)
+      };
+
+      completed.done()
+   }
+}
+
+public cancellationCloseRaceTest() : testCase()
+{
+   int workers := MtaLoad.WorkerCount;
+   int rounds := MtaLoad.Repetitions;
+   auto sources := Array.allocate(rounds);
+   auto registrationRows := Array.allocate(rounds);
+   auto callbackRows := Array.allocate(rounds);
+   auto completed := Array.allocate(rounds);
+
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto source := CancellationTokenSource.new();
+      auto registrations := Array.allocate(workers);
+      auto callbacks := Array.allocate(workers);
+
+      for (int i := 0; i < workers; i += 1)
+      {
+         auto callback := OnceCallback.new();
+         callbacks[i] := callback;
+         registrations[i] := source.Token.register(callback)
+      };
+
+      sources[round] := source;
+      registrationRows[round] := registrations;
+      callbackRows[round] := callbacks;
+      completed[round] := Latch.new(workers)
+   };
+
+   CloseRaceState state := new CloseRaceState();
+   state.Registrations := registrationRows;
+   state.Completed := completed;
+   state.Barrier := RoundBarrier.new(workers, rounds);
+   state.Rounds := rounds;
+   state.Errors := ErrorBox.new();
+
+   for (int i := 0; i < workers; i += 1)
+   {
+      CloseRaceWorkerArg arg := new CloseRaceWorkerArg();
+      arg.Index := i;
+      arg.State := state;
+
+      Thread worker := Thread.assign(&closeRaceWorker);
+      worker.start(arg)
+   };
+
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto source := sources[round];
+      auto done := completed[round];
+      auto callbacks := callbackRows[round];
+
+      state.Barrier.releaseAll(round);
+      try
+      {
+         source.cancel()
+      }
+      catch(AggregateException e)
+      {
+         Exception[] failures := e.InnerExceptions;
+         failures[0].raise()
+      };
+      done.await();
+
+      for (int i := 0; i < workers; i += 1)
+      {
+         auto callback := callbacks[i];
+         Assert.ifTrue(callback.Calls <= 1);
+         Assert.ifFalse(callback.Duplicated)
+      }
+   };
+
+   state.Errors.rethrowIfAny();
+   state.Barrier.close();
+   for (int round := 0; round < rounds; round += 1)
+   {
+      auto done := completed[round];
+      done.close()
+   };
+
+   Console.write(".")
+}

--- a/tests60/mta_tests/mta_tests.prj
+++ b/tests60/mta_tests/mta_tests.prj
@@ -36,6 +36,7 @@
         <include>sync_tests.l</include>
         <include>core_tests.l</include>
         <include>tls_tests.l</include>
+        <include>cancellation_tests.l</include>
      </module>
   </files>
 </configuration>


### PR DESCRIPTION
# Description

Adds cancellation tokens and cooperative cancellation support for tasks and async operations, including token-aware task states, exception propagation, registrations and whenAll behavior

It also fixes a race in Task.whenAll and adds functional, worst-case and concurrent stress tests

Tested on Linux i386 and amd64:

- system_tests
- mta_tests
- async_tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update