### PR TITLE
Fix stream segment reads and writes with offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ examples60/db/sqlite/bin
 .vs/
 .DS_Store
 .idea
-.dat
+*.dat

--- a/doc/whatsnew
+++ b/doc/whatsnew
@@ -49,6 +49,7 @@
   - [FIXED] cancellation registration close waits for callbacks already in progress
   - [FIXED] binary heap ordering after removing an arbitrary item
   - [REDUX] enum template - is returning a constant directly
+  - [FIXED] Stream segment reads and writes honor offsets and lengths
 
 - Scripts
 

--- a/src60/system/io/common.l
+++ b/src60/system/io/common.l
@@ -36,50 +36,11 @@ namespace io
       abstract int read(byte[] dump, int length);
         
       abstract write(byte[] dump, int length);
-        
-      int read(byte[] dump, int offset, int length)
-      {
-         int maxLength := length;
-         int actualRead := 0;
-         int actualOffset := offset;
 
-         byte tempbuffer[1024];
-         while (maxLength > 0) {
-            int pageSize := (maxLength < 1024) ? maxLength : 1024;
-            pageSize := read(tempbuffer, pageSize);
-            if (pageSize == 0) { 
-               :break
-            };
+      abstract int read(byte[] dump, int offset, int length);
 
-            class Array<byte>.copy(dump, tempbuffer, actualOffset, pageSize);
+      abstract write(byte[] dump, int offset, int length);
 
-            actualRead += pageSize;
-            actualOffset += pageSize;
-
-            maxLength += pageSize;
-         };
-
-         ^ actualRead;
-      }
-        
-      write(byte[] dump, int offset, int length)
-      {
-         int actualLen := length;
-         int actualOffset := offset;
-
-         byte tempbuffer[1024];
-         while (actualLen > 0) {
-            int pageSize := (actualLen < 1024) ? actualLen : 1024;
-
-            class Array<byte>.copy(tempbuffer, dump, actualOffset, pageSize);
-
-            write(tempbuffer, pageSize);
-
-            actualLen -= pageSize;
-            actualOffset += pageSize;
-         }
-      }
-        
       abstract close();
    }
 }

--- a/src60/system/io/files.l
+++ b/src60/system/io/files.l
@@ -68,6 +68,26 @@ namespace io
                 ref written,
                 0)
       }
+
+      write(byte[] dump, int offset, int length)
+      {
+         if (offset < 0 || length < 0 || offset > dump.Length - length)
+            { OutOfRangeException.raise() };
+
+         byte buffer[1024];
+
+         int remaining := length;
+         int index := offset;
+         while (remaining > 0) {
+            int pageSize := (remaining < 1024) ? remaining : 1024;
+
+            Array<byte>.copy(buffer, dump, index, pageSize);
+            self.write(buffer, pageSize);
+
+            index += pageSize;
+            remaining -= pageSize
+         }
+      }
     
       int read(byte[] dump, int len)
       {
@@ -81,7 +101,33 @@ namespace io
 
          ^ temp
       }
-    
+
+      int read(byte[] dump, int offset, int length)
+      {
+         if (offset < 0 || length < 0 || offset > dump.Length - length)
+            { OutOfRangeException.raise() };
+
+         byte buffer[1024];
+
+         int remaining := length;
+         int index := offset;
+         int totalRead := 0;
+         while (remaining > 0) {
+            int pageSize := (remaining < 1024) ? remaining : 1024;
+            int read := self.read(buffer, pageSize);
+            if (read == 0)
+               { :break };
+
+            Array<byte>.copyTo(dump, buffer, index, read);
+
+            index += read;
+            remaining -= read;
+            totalRead += read
+         };
+
+         ^ totalRead
+      }
+
       int Index
       {    
          get()
@@ -281,6 +327,26 @@ namespace io
             length,
             _handle)
       }
+
+      write(byte[] dump, int offset, int length)
+      {
+         if (offset < 0 || length < 0 || offset > dump.Length - length)
+            { OutOfRangeException.raise() };
+
+         byte buffer[1024];
+
+         int remaining := length;
+         int index := offset;
+         while (remaining > 0) {
+            int pageSize := (remaining < 1024) ? remaining : 1024;
+
+            Array<byte>.copy(buffer, dump, index, pageSize);
+            self.write(buffer, pageSize);
+
+            index += pageSize;
+            remaining -= pageSize
+         }
+      }
     
       int read(byte[] dump, int length)
       {
@@ -289,10 +355,36 @@ namespace io
                      1,
                      length,
                      _handle);
-    
+
          ^ n
       }
-    
+
+      int read(byte[] dump, int offset, int length)
+      {
+         if (offset < 0 || length < 0 || offset > dump.Length - length)
+            { OutOfRangeException.raise() };
+
+         byte buffer[1024];
+
+         int remaining := length;
+         int index := offset;
+         int totalRead := 0;
+         while (remaining > 0) {
+            int pageSize := (remaining < 1024) ? remaining : 1024;
+            int read := self.read(buffer, pageSize);
+            if (read == 0)
+               { :break };
+
+            Array<byte>.copyTo(dump, buffer, index, read);
+
+            index += read;
+            remaining -= read;
+            totalRead += read
+         };
+
+         ^ totalRead
+      }
+
       int Index
       {    
          get()

--- a/src60/system/io/memorystream.l
+++ b/src60/system/io/memorystream.l
@@ -84,6 +84,9 @@ namespace io
         
       write(int index, int length, byte[] array)
       {
+         if (index < 0 || length < 0 || index > array.Length - length)
+            { OutOfRangeException.raise() };
+
          int used := _used.Value;        
          int capacity := _capacity.Value;
             
@@ -114,13 +117,18 @@ namespace io
       }
         
       read(int index, int length, byte[] array)
+         <= read(index, 0, length, array);
+
+      read(int index, int offset, int length, byte[] array)
       {
          int used := _used.Value;
-            
-         if(index + length > used)
+
+         if (index < 0 || length < 0 || index > used - length || offset < 0 || offset > array.Length - length)
             { OutOfRangeException.raise() };
-                
-         Array<byte>.copy(array, _buffer, index, length);
+
+         for (int i := 0; i < length; i += 1) {
+            array[offset + i] := _buffer[index + i]
+         }
       }
         
       delete(int index, int length)
@@ -182,17 +190,21 @@ namespace io
       }
         
       write(byte[] dump, int length)
+         <= write(dump, 0, length);
+
+      write(byte[] dump, int offset, int length)
       {
-         _buffer.write(0, length, dump)
-      }
-    
-      write(byte[] dump, int index, int length)
-      {
-         _buffer.write(index, length, dump)
+         _buffer.write(offset, length, dump)
       }
     
       int read(byte[] dump, int len)
+         = self.read(dump, 0, len);
+
+      int read(byte[] dump, int offset, int len)
       {
+         if (offset < 0 || len < 0 || offset > dump.Length - len)
+            { OutOfRangeException.raise() };
+
          int totalLen := _buffer.Length;
          int pos := _position.Value;
             
@@ -200,7 +212,7 @@ namespace io
          if (len > totalLen - pos)
             actualLen := totalLen - pos;
             
-         _buffer.read(pos, actualLen, dump);
+         _buffer.read(pos, offset, actualLen, dump);
     
          _position.append(actualLen);
 
@@ -218,7 +230,7 @@ namespace io
          set(int index)
          {
             int pos := _buffer.Length;
-            if (pos < index)
+            if (index < 0 || pos < index)
                { OutOfRangeException.raise() };
                     
             _position.Value := index

--- a/src60/system/net/networkstream.l
+++ b/src60/system/net/networkstream.l
@@ -57,7 +57,25 @@ public class NetworkStream : Stream
    }
 
    int read(byte[] dump, int length)
-      = _socket.read(dump, length);
+      = self.read(dump, 0, length);
+
+   int read(byte[] dump, int offset, int length)
+   {
+      if (offset < 0 || length < 0 || offset > dump.Length - length)
+         { OutOfRangeException.raise() };
+
+      if (offset == 0)
+         { ^ _socket.read(dump, length) };
+
+      byte buffer[1024];
+
+      int pageSize := (length < 1024) ? length : 1024;
+      int read := _socket.read(buffer, pageSize);
+
+      Array<byte>.copyTo(dump, buffer, offset, read);
+
+      ^ read
+   }
      
    indexed internal Task<int> readAsync(byte[] dump, int length)
       = _socket.readAsync(dump, length);
@@ -74,10 +92,36 @@ public class NetworkStream : Stream
          });
 
    int write(byte[] dump, int length)
-   {
-      int retVal := _socket.write(dump, length);
+      = self.write(dump, 0, length);
 
-      ^ retVal
+   int write(byte[] dump, int offset, int length)
+   {
+      if (offset < 0 || length < 0 || offset > dump.Length - length)
+         { OutOfRangeException.raise() };
+
+      byte buffer[1024];
+
+      int remaining := length;
+      int index := offset;
+      int totalWritten := 0;
+      while (remaining > 0) {
+         int pageSize := (remaining < 1024) ? remaining : 1024;
+         byte[] page := dump;
+         if (index != 0) {
+            Array<byte>.copy(buffer, dump, index, pageSize);
+            page := buffer
+         };
+
+         int written := _socket.write(page, pageSize);
+         if (written == 0)
+            { :break };
+
+         index += written;
+         remaining -= written;
+         totalWritten += written
+      };
+
+      ^ totalWritten
    }
      
    indexed internal Task<int> writeAsync(byte[] dump, int length)

--- a/tests60/system_tests/stream_tests.l
+++ b/tests60/system_tests/stream_tests.l
@@ -1,0 +1,123 @@
+import system'io;
+import extensions;
+import ltests;
+
+public streamSegmentReadTest() : testCase()
+{
+   byte[] source := new byte[](8);
+   for (int i := 0; i < source.Length; i += 1) {
+      source[i] := i + 1
+   };
+
+   Stream stream := MemoryStream.load(source);
+   byte[] target := new byte[](9);
+   for (int i := 0; i < target.Length; i += 1) {
+      target[i] := 99
+   };
+
+   int read := stream.read(target, 2, 5);
+
+   Assert.ifEqual(read, 5);
+   Assert.ifEqual(stream.Index, 5);
+   Assert.ifEqual(target[1], 99);
+   Assert.ifEqual(target[2], 1);
+   Assert.ifEqual(target[6], 5);
+   Assert.ifEqual(target[7], 99);
+
+   read := stream.read(target, 7, 2);
+   Assert.ifEqual(read, 2);
+   Assert.ifEqual(stream.Index, 7);
+   Assert.ifEqual(target[7], 6);
+   Assert.ifEqual(target[8], 7);
+
+   read := stream.read(target, 0, 2);
+   Assert.ifEqual(read, 1);
+   Assert.ifEqual(stream.Index, 8);
+   Assert.ifEqual(target[0], 8);
+
+   Console.write(".")
+}
+
+public streamSegmentWriteTest() : testCase()
+{
+   byte[] source := new byte[](8);
+   for (int i := 0; i < source.Length; i += 1) {
+      source[i] := i + 1
+   };
+
+   MemoryStream stream := new MemoryStream();
+   Stream output := stream;
+
+   output.write(source, 2, 4);
+
+   byte[] written := new byte[](4);
+   Assert.ifEqual(stream.read(written, 4), 4);
+   Assert.ifEqual(written[0], 3);
+   Assert.ifEqual(written[3], 6);
+
+   Console.write(".")
+}
+
+public streamSegmentRangeTest() : testCase()
+{
+   byte[] source := new byte[](4);
+   Stream stream := MemoryStream.load(source);
+
+   bool readFailed := false;
+   try {
+      stream.read(source, 3, 2)
+   }
+   catch (OutOfRangeException e) {
+      readFailed := true
+   };
+
+   bool writeFailed := false;
+   try {
+      stream.write(source, -1, 1)
+   }
+   catch (OutOfRangeException e) {
+      writeFailed := true
+   };
+
+   Assert.ifTrue(readFailed);
+   Assert.ifTrue(writeFailed);
+
+   Console.write(".")
+}
+
+public fileStreamSegmentTest() : testCase()
+{
+   string path := "stream_segment_test.tmp";
+   try {
+      byte[] source := new byte[](2054);
+      for (int i := 0; i < source.Length; i += 1) {
+         source[i] := i & 255
+      };
+
+      using(Stream output := FileStream.openForReWrite(path)) {
+         output.write(source, 3, 2048)
+      };
+
+      byte[] target := new byte[](2052);
+      for (int i := 0; i < target.Length; i += 1) {
+         target[i] := 99
+      };
+      Assert.ifEqual(target[2050], 99);
+
+      using(Stream input := FileStream.openForRead(path)) {
+         int read := input.read(target, 2, 2048);
+
+         Assert.ifEqual(read, 2048);
+         Assert.ifEqual(target[1], 99);
+         Assert.ifEqual(target[2], 3);
+         Assert.ifEqual(target[1025], 2);
+         Assert.ifEqual(target[2049], 2);
+         Assert.ifEqual(target[2050], 99)
+      }
+   }
+   finally {
+      File.assign(path).delete()
+   };
+
+   Console.write(".")
+}

--- a/tests60/system_tests/system_tests.prj
+++ b/tests60/system_tests/system_tests.prj
@@ -39,6 +39,7 @@
         <include>main.l</include>
         <include>basic.l</include>
         <include>declarations.l</include>
+        <include>stream_tests.l</include>
      </module>
   </files>
 </configuration>


### PR DESCRIPTION
# Description
Fixes Stream segment reads and writes so buffer offsets and lengths are handled correctly across MemoryStream, FileStream, and NetworkStream.

Adds range validation and regression coverage for segmented operations, page boundaries, and untouched buffer regions.

Tested with system_tests on Linux i386 and amd64.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] This change requires a documentation update